### PR TITLE
feat: add indicator if already voted for a proposal on summary

### DIFF
--- a/src/templates/summary/index.hbs
+++ b/src/templates/summary/index.hbs
@@ -16,8 +16,13 @@
                   <a href="{{ link }}" target="_blank">{{ title }}</a>
                 </div>
                 <div>
-                  {{ body }}
+                  {{ shortBody }}
                 </div>
+                {{#if voted}}
+                  <div>
+                    You participated
+                  </div>
+                {{/if}}
               </div>
             {{/each}}
           </div>
@@ -42,6 +47,11 @@
                 <div>
                   {{ shortBody }}
                 </div>
+                {{#if voted}}
+                  <div>
+                    You participated
+                  </div>
+                {{/if}}
               </div>
             {{/each}}
           </div>
@@ -66,6 +76,11 @@
                 <div>
                   {{ shortBody }}
                 </div>
+                {{#if voted}}
+                  <div>
+                    You participated
+                  </div>
+                {{/if}}
               </div>
             {{/each}}
           </div>


### PR DESCRIPTION
Add an indicator if already voted for a proposal on summary

Current indicator in template is a placeholder, will need to be improved via #6 