### PR TITLE
feat: summary email for multiple addresses

### DIFF
--- a/src/helpers/snapshot.ts
+++ b/src/helpers/snapshot.ts
@@ -17,8 +17,8 @@ const client = new ApolloClient({
 });
 
 const FOLLOWS_QUERY = gql`
-  query Follows($follower: String) {
-    follows(where: { follower: $follower }, first: 100) {
+  query Follows($follower_in: [String]) {
+    follows(where: { follower_in: $follower_in }, first: 100) {
       space {
         id
       }
@@ -45,8 +45,8 @@ const PROPOSALS_QUERY = gql`
 `;
 
 const VOTES_QUERY = gql`
-  query Votes($proposal_in: [String], $voter: String) {
-    votes(where: { proposal_in: $proposal_in, voter: $voter }, first: 100) {
+  query Votes($proposal_in: [String], $voter_in: [String]) {
+    votes(where: { proposal_in: $proposal_in, voter_in: $voter_in }, first: 100) {
       id
       proposal {
         id
@@ -55,7 +55,7 @@ const VOTES_QUERY = gql`
   }
 `;
 
-export const fetchProposals = async (address: string) => {
+export const fetchProposals = async (addresses: string[]) => {
   const now = Math.floor(Date.now() / 1e3);
 
   const {
@@ -63,7 +63,7 @@ export const fetchProposals = async (address: string) => {
   } = await client.query({
     query: FOLLOWS_QUERY,
     variables: {
-      follower: address
+      follower_in: addresses
     }
   });
 
@@ -83,15 +83,15 @@ export const fetchProposals = async (address: string) => {
     query: VOTES_QUERY,
     variables: {
       proposal_in: proposals.map(proposal => proposal.id),
-      voter: address
+      voter_in: addresses
     }
   });
 
   return { proposals, votes };
 };
 
-export async function getProposals(address: string, maxShortBodyLength = 150) {
-  const { proposals, votes } = await fetchProposals(address);
+export async function getProposals(addresses: string[], maxShortBodyLength = 150) {
+  const { proposals, votes } = await fetchProposals(addresses);
 
   const groupedProposals = {
     pending: [],

--- a/src/preview/index.ts
+++ b/src/preview/index.ts
@@ -6,7 +6,7 @@ import constants from '../helpers/constants.json';
 export default async function preview(req, res) {
   const params = {
     to: constants.example.to,
-    address: constants.example.address
+    address: [constants.example.address]
   };
   const { template } = req.params;
   let msg;

--- a/test/unit/helpers/snapshot.test.ts
+++ b/test/unit/helpers/snapshot.test.ts
@@ -28,7 +28,7 @@ describe('snapshot', () => {
     it.each([['active'], ['closed'], ['pending']])(
       'groups the proposals by %s status',
       async status => {
-        const results = await testSnapshot.getProposals(['']);
+        const results = await testSnapshot.getProposals([]);
 
         expect(results[status].map(s => s.proposals.map(p => p.id)).flat()).toEqual(
           expectedProposalsByStatus[status]
@@ -37,7 +37,7 @@ describe('snapshot', () => {
     );
 
     it('groups the proposals by space', async () => {
-      const results = await testSnapshot.getProposals(['']);
+      const results = await testSnapshot.getProposals([]);
 
       Object.keys(results).forEach(status => {
         expect(
@@ -50,13 +50,13 @@ describe('snapshot', () => {
     });
 
     it.each(expectedShortBody)('truncates the body when necessary', async data => {
-      const results = await testSnapshot.getProposals([''], data.length);
+      const results = await testSnapshot.getProposals([], data.length);
 
       expect(proposalsById(results, data.id).shortBody).toBe(data.shortBody);
     });
 
     it('includes whether the address has voted in the proposal', async () => {
-      const results = await testSnapshot.getProposals(['']);
+      const results = await testSnapshot.getProposals([]);
 
       Object.values(results)
         .flat()
@@ -70,7 +70,7 @@ describe('snapshot', () => {
     it.each(expectedSanitazedShortBody)(
       'strips all markdown tags from the shortBody',
       async data => {
-        const results = await testSnapshot.getProposals(['']);
+        const results = await testSnapshot.getProposals([]);
 
         expect(proposalsById(results, data.id).shortBody).toBe(data.shortBody);
       }

--- a/test/unit/helpers/snapshot.test.ts
+++ b/test/unit/helpers/snapshot.test.ts
@@ -28,7 +28,7 @@ describe('snapshot', () => {
     it.each([['active'], ['closed'], ['pending']])(
       'groups the proposals by %s status',
       async status => {
-        const results = await testSnapshot.getProposals('');
+        const results = await testSnapshot.getProposals(['']);
 
         expect(results[status].map(s => s.proposals.map(p => p.id)).flat()).toEqual(
           expectedProposalsByStatus[status]
@@ -37,7 +37,7 @@ describe('snapshot', () => {
     );
 
     it('groups the proposals by space', async () => {
-      const results = await testSnapshot.getProposals('');
+      const results = await testSnapshot.getProposals(['']);
 
       Object.keys(results).forEach(status => {
         expect(
@@ -50,13 +50,13 @@ describe('snapshot', () => {
     });
 
     it.each(expectedShortBody)('truncates the body when necessary', async data => {
-      const results = await testSnapshot.getProposals('', data.length);
+      const results = await testSnapshot.getProposals([''], data.length);
 
       expect(proposalsById(results, data.id).shortBody).toBe(data.shortBody);
     });
 
     it('includes whether the address has voted in the proposal', async () => {
-      const results = await testSnapshot.getProposals('');
+      const results = await testSnapshot.getProposals(['']);
 
       Object.values(results)
         .flat()
@@ -70,7 +70,7 @@ describe('snapshot', () => {
     it.each(expectedSanitazedShortBody)(
       'strips all markdown tags from the shortBody',
       async data => {
-        const results = await testSnapshot.getProposals('');
+        const results = await testSnapshot.getProposals(['']);
 
         expect(proposalsById(results, data.id).shortBody).toBe(data.shortBody);
       }


### PR DESCRIPTION
This PR show all proposals for all the addresses related to the same email address in the same summary email.