### PR TITLE
fix: fix missing preheader injection in templates

### DIFF
--- a/src/templates/builder.ts
+++ b/src/templates/builder.ts
@@ -29,7 +29,8 @@ export default function buildMessage(id: string, params: any) {
       compile(template.html)({
         ...params,
         host: process.env.HOST,
-        subject: template.subject
+        subject: template.subject,
+        preheader: template.preheader
       }),
       {
         extraCss: sass.compile('./src/templates/styles/styles.scss').css


### PR DESCRIPTION
`preheader` was defined in templates/index.ts, but were never injected properly in the handlebars files