### PR TITLE
fix: fix missing `DEFAULT` value in schema

### DIFF
--- a/src/helpers/schema.sql
+++ b/src/helpers/schema.sql
@@ -2,7 +2,7 @@ CREATE TABLE subscribers (
   email VARCHAR(256) NOT NULL,
   address VARCHAR(256) NOT NULL,
   created BIGINT NOT NULL,
-  verified BIGINT NOT NULL,
+  verified BIGINT NOT NULL DEFAULT 0,
   PRIMARY KEY (email, address),
   INDEX created (created)
 );


### PR DESCRIPTION
Fix missing default value for `verified` column in the sql schema