### PR TITLE
fix: fix wrong proposals stats

### DIFF
--- a/src/helpers/snapshot.ts
+++ b/src/helpers/snapshot.ts
@@ -97,7 +97,7 @@ export async function getProposals(
 ) {
   const { proposals, votes } = await fetchProposals(addresses, endDate);
 
-  const groupedProposals = {
+  const groupedProposals: Record<string, { space: any; proposals: any[] }[]> = {
     pending: [],
     active: [],
     closed: []

--- a/src/templates/summary/html.hbs
+++ b/src/templates/summary/html.hbs
@@ -13,13 +13,13 @@
             <tbody>
               <tr>
                 <td class="bordered">
-                  <strong>{{proposals.pending.length}}</strong>
+                  <strong>{{stats.pending}}</strong>
                 Pending proposals</td>
                 <td class="bordered">
-                <strong>{{proposals.active.length}}</strong>
+                <strong>{{stats.active}}</strong>
               Active proposals</td>
                 <td>
-                <strong>{{proposals.closed.length}}</strong>
+                <strong>{{stats.closed}}</strong>
               Closed proposals</td>
               </tr>
             </tbody>

--- a/src/templates/summary/index.ts
+++ b/src/templates/summary/index.ts
@@ -28,11 +28,20 @@ export default async function prepare(params: any) {
   const startDate = new Date(params.endDate);
   startDate.setDate(startDate.getDate() - 7);
 
+  const stats: Record<string, number> = {};
+
+  for (const [key, value] of Object.entries(proposals)) {
+    stats[key] = value
+      .map(groupedSpace => groupedSpace.proposals.length)
+      .reduce((total, count) => total + count, 0);
+  }
+
   return buildMessage('summary', {
     ...params,
     startDate,
     formattedStartDate: formatDate(startDate),
     formattedEndDate: formatDate(params.endDate),
-    proposals
+    proposals,
+    stats
   });
 }


### PR DESCRIPTION
# Issues

In email summary, the total stats count for each status (active/pending/closed) was reflecting the number of spaces for each status, instead of the total number of proposals.

# Changes

Show the proposals count, instead of spaces count