### PR TITLE
feat: requires a signature for subscription

### DIFF
--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -18,14 +18,17 @@ router.post('/', async (req, res) => {
 
   try {
     if (method === 'snapshot.subscribe') {
-      if (!isValidEmail(params.email) || !isValidAddress(params.address)) {
+      if (!isValidEmail(params.email) || !isValidAddress(params.address) || !params.signature) {
         return rpcError(res, 400, 'Invalid params', id);
       }
 
-      await subscribe(params.email, params.address);
-      queueSubscribe(params.email, params.address);
+      if (verifySubscribe(params.email, params.address, params.signature, params.address)) {
+        await subscribe(params.email, params.address);
+        queueSubscribe(params.email, params.address);
+        return rpcSuccess(res, 'OK', id);
+      }
 
-      return rpcSuccess(res, 'OK', id);
+      return rpcError(res, 500, 'Unable to authenticate the request', id);
     } else if (method === 'snapshot.verify') {
       if (verifySubscribe(params.email, params.address, params.signature)) {
         await verify(params.email, params.address);

--- a/test/unit/sign/index.test.ts
+++ b/test/unit/sign/index.test.ts
@@ -1,5 +1,3 @@
-process.env.WALLET_PRIVATE_KEY = '1c35d78975cadb12e4047a70a38bade91d2fd9d502884785797db3e9148ec5e2';
-
 import { subscribe, verifySubscribe } from '../../../src/sign';
 
 describe('sign', () => {


### PR DESCRIPTION
# Issue 

Creating a subscription did not check for wallet ownership, anyone could register an email with any address

# Changes

Wallet ownership is now enforced, by requiring the user to sign a message with his wallet, before submitting the subscription, on snapshot.org

