### PR TITLE
fix: fix high CPU usage on production server

### DIFF
--- a/src/queues/index.ts
+++ b/src/queues/index.ts
@@ -1,11 +1,31 @@
 import Queue from 'bull';
+import Redis from 'ioredis';
 import summaryProcessor from './processors/summary';
 import schedulerProcessor from './processors/scheduler';
 import constants from '../helpers/constants.json';
 import subscribeProcessor from './processors/subscribe';
 
-export const mailerQueue = new Queue('mailer', process.env.REDIS_URL as string);
-export const scheduleQueue = new Queue('scheduler', process.env.REDIS_URL as string);
+const REDIS_URL = (process.env.REDIS_URL as string) || 'redis://127.0.0.1:6379';
+const REDIS_OPTS = { maxRetriesPerRequest: null, enableReadyCheck: false };
+
+const client = new Redis(REDIS_URL, REDIS_OPTS);
+const subscriber = new Redis(REDIS_URL, REDIS_OPTS);
+
+const opts = {
+  createClient: function (type: string) {
+    switch (type) {
+      case 'client':
+        return client;
+      case 'subscriber':
+        return subscriber;
+      default:
+        return new Redis(REDIS_URL, REDIS_OPTS);
+    }
+  }
+};
+
+export const mailerQueue = new Queue('mailer', opts);
+export const scheduleQueue = new Queue('scheduler', opts);
 
 export function start() {
   console.log('[QUEUE-MAILER] Starting queue mailer');


### PR DESCRIPTION
Fix issue causing 100% CPU usage when using a remote redis instance.

This issue does not arise when using a local redis instance (redis://127.0.0.1:6379), and only happens when using a remote redis (production case).

Issue was fixed by re-using redis connection when possible (https://github.com/OptimalBits/bull/blob/master/PATTERNS.md#reusing-redis-connections), and explicitly set the redis options (https://github.com/OptimalBits/bull/issues/1873#issuecomment-950873766)