### PR TITLE
feat: ensure email will be processed only once

### DIFF
--- a/src/queues/processors/scheduler.ts
+++ b/src/queues/processors/scheduler.ts
@@ -15,6 +15,9 @@ export default async () => {
         email: result.email,
         startTimestamp: +summaryTimeRange.start,
         endTimestamp: +summaryTimeRange.end
+      },
+      opts: {
+        jobId: `summary-${result.email}-${+summaryTimeRange.start}`
       }
     }))
   );


### PR DESCRIPTION
Adding a jobId will ensure this job execute only once.

Re-queuing this job with same ID will skip subsequent processing, ensuring job idempotency