### PR TITLE
fix: fix issue when trying to pad a string already longer than the target length

### DIFF
--- a/src/templates/builder.ts
+++ b/src/templates/builder.ts
@@ -1,7 +1,7 @@
 import { compile } from 'handlebars';
 import juice from 'juice';
 import sass from 'sass';
-import { unsubscribeLink, loadPartials } from './utils';
+import { unsubscribeLink, loadPartials, formatPreheader } from './utils';
 import templates from './';
 import type { Message, TemplatePrepareParams, TemplateId } from '../../types';
 
@@ -27,11 +27,7 @@ export default async function buildMessage(id: TemplateId, params: TemplatePrepa
     headers['List-Unsubscribe'] = `<${extraParams.unsubscribeLink}>`;
   }
 
-  if (extraParams.preheader.length > 0) {
-    extraParams.preheader = `${extraParams.preheader}${'&nbsp;&zwnj;'.repeat(
-      150 - extraParams.preheader.length
-    )}`;
-  }
+  extraParams.preheader = formatPreheader(extraParams.preheader);
 
   return {
     to: params.to,

--- a/src/templates/utils.ts
+++ b/src/templates/utils.ts
@@ -33,3 +33,11 @@ export function formatProposalHtmlBody(body: string, isTruncated: boolean) {
     (isTruncated ? '<a href="${proposal.link}">(read more)</a>' : '')
   );
 }
+
+export function formatPreheader(text: string, maxLength = 150) {
+  if (text.length > 0 && text.length < maxLength) {
+    return `${text}${'&nbsp;&zwnj;'.repeat(maxLength - text.length)}`;
+  }
+
+  return text;
+}


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

The string padding code is not taking into account string longer than the expected max length, and results in calling `repeat()` with a negative value.

## 💊 Fixes / Solution

Fix #76

Avoid padding the string when it is already exceeding the string limit.

## 🚧 Changes

- Add a check to skip padding when the string does not need padding

## 🛠️ Tests

Internal change only. Since we already control the length of the string in templates/index.ts, this fix is just a prevention