### PR TITLE
feat: separate update and unsubscribe link in footer

### DIFF
--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -66,7 +66,7 @@ router.post('/', async (req, res) => {
         verifyUpdate(
           params.email,
           params.address,
-          params.address.length > 0 ? params.subscriptions : [],
+          params.address && params.address.length > 0 ? params.subscriptions : [],
           params.signature
         )
       ) {

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -60,16 +60,16 @@ router.post('/', async (req, res) => {
         return rpcError(res, 'INVALID_PARAMS', id);
       }
 
-      if (
-        // Do not check `subscriptions` for requests coming from
-        // envelop-ui, signed by backend
-        verifyUpdate(
-          params.email,
-          params.address,
-          params.address && params.address.length > 0 ? params.subscriptions : [],
-          params.signature
-        )
-      ) {
+      // Do not check `subscriptions` for requests coming from
+      // envelop-ui, signed by backend
+      const isValidSignature = verifyUpdate(
+        params.email,
+        params.address,
+        params.address && params.address.length > 0 ? params.subscriptions : [],
+        params.signature
+      );
+
+      if (isValidSignature) {
         await update(params.email, params.address, params.subscriptions);
         return rpcSuccess(res, 'OK', id);
       }

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -60,7 +60,16 @@ router.post('/', async (req, res) => {
         return rpcError(res, 'INVALID_PARAMS', id);
       }
 
-      if (verifyUpdate(params.email, params.address, params.subscriptions, params.signature)) {
+      if (
+        // Do not check `subscriptions` for requests coming from
+        // envelop-ui, signed by backend
+        verifyUpdate(
+          params.email,
+          params.address,
+          params.address.length > 0 ? params.subscriptions : [],
+          params.signature
+        )
+      ) {
         await update(params.email, params.address, params.subscriptions);
         return rpcSuccess(res, 'OK', id);
       }

--- a/src/templates/builder.ts
+++ b/src/templates/builder.ts
@@ -1,7 +1,7 @@
 import { compile } from 'handlebars';
 import juice from 'juice';
 import sass from 'sass';
-import { unsubscribeLink, loadPartials } from './utils';
+import { unsubscribeLink, updateSubscriptionsLink, loadPartials } from './utils';
 import templates from './';
 import type { Message, TemplatePrepareParams, TemplateId } from '../../types';
 
@@ -15,6 +15,7 @@ export default async function buildMessage(id: TemplateId, params: TemplatePrepa
     host: string;
     subject: string;
     unsubscribeLink?: string;
+    updateSubscriptionsLink?: string;
     preheader: string;
   } = {
     host: process.env.HOST as string,
@@ -24,6 +25,7 @@ export default async function buildMessage(id: TemplateId, params: TemplatePrepa
 
   if (id !== 'subscribe') {
     extraParams.unsubscribeLink = await unsubscribeLink(params.to);
+    extraParams.updateSubscriptionsLink = await updateSubscriptionsLink(params.to);
     headers['List-Unsubscribe'] = `<${extraParams.unsubscribeLink}>`;
   }
 

--- a/src/templates/partials/layout.html.hbs
+++ b/src/templates/partials/layout.html.hbs
@@ -64,7 +64,9 @@
                 {{#if unsubscribeLink}}
                   You are receiving this email because you are subscribed to Snapshot summary report.
                   <br/>
-                  <a href="{{updateSubscriptionsLink}}">Update your email preference</a> | <a href="{{unsubscribeLink}}">Unsubscribe</a>
+                  <a href="{{updateSubscriptionsLink}}">Update your email preference</a>
+                  <span style="padding: 0 0.5em">|</span>
+                  <a href="{{unsubscribeLink}}">Unsubscribe</a>
                 {{/if}}
               </td>
             </tr>

--- a/src/templates/partials/layout.html.hbs
+++ b/src/templates/partials/layout.html.hbs
@@ -64,7 +64,7 @@
                 {{#if unsubscribeLink}}
                   You are receiving this email because you are subscribed to Snapshot summary report.
                   <br/>
-                  <a href="{{unsubscribeLink}}">Unsubscribe</a> to stop receiving this kind of email.
+                  <a href="{{updateSubscriptionsLink}}">Update your email preference</a> | <a href="{{unsubscribeLink}}">Unsubscribe</a>
                 {{/if}}
               </td>
             </tr>

--- a/src/templates/partials/layout.text.hbs
+++ b/src/templates/partials/layout.text.hbs
@@ -2,5 +2,6 @@
 {{#if unsubscribeLink}}
 
 --------------------
-To manage your email preferences or to unsubscribe, follow this link: {{{unsubscribeLink}}}
+To manage your email preferences, follow this link: {{{updateSubscriptionsLink}}}
+To unsubscribe, follow this link: {{{unsubscribeLink}}}
 {{/if}}

--- a/src/templates/utils.ts
+++ b/src/templates/utils.ts
@@ -1,10 +1,27 @@
 import fs from 'fs';
 import Handlebars from 'handlebars';
-import { signUnsubscribe } from '../sign';
+import { signUnsubscribe, signUpdate } from '../sign';
 
 export async function unsubscribeLink(email: string) {
   return `${process.env.FRONT_HOST}/#/unsubscribe?${new URLSearchParams({
     signature: await signUnsubscribe(email),
+    email: email
+  }).toString()}`;
+}
+
+/**
+ * Generate an updateSubscription link, signed by the backend
+ * To be used in email footer, together with envelop-ui
+ *
+ * NOTE: This link uses a signature with an empty subscriptions, which will be
+ * reused when envelop-ui send back the update request, to avoid
+ * requesting the user for a signature when submitting the request.
+ * Subscriptions params will be ignored when checking for signature validity
+ * for all requests signed by envelop
+ */
+export async function updateSubscriptionsLink(email: string) {
+  return `${process.env.FRONT_HOST}/#/update?${new URLSearchParams({
+    signature: await signUpdate(email, '', []),
     email: email
   }).toString()}`;
 }

--- a/test/e2e/update.test.ts
+++ b/test/e2e/update.test.ts
@@ -136,7 +136,7 @@ describe('POST update', () => {
             email,
             address: '',
             subscriptions: ['newProposal'],
-            signature: await signUpdate(email, '', ['newProposal'])
+            signature: await signUpdate(email, '', [])
           }
         });
       const unverified = await db.queryAsync(

--- a/test/unit/templates/index.test.ts
+++ b/test/unit/templates/index.test.ts
@@ -1,5 +1,5 @@
 import buildMessage from '../../../src/templates/builder';
-import { unsubscribeLink } from '../../../src/templates/utils';
+import { unsubscribeLink, updateSubscriptionsLink } from '../../../src/templates/utils';
 
 describe('templates', () => {
   const email = 'test@test.com';
@@ -15,8 +15,25 @@ describe('templates', () => {
     expect(result.headers!['List-Unsubscribe']).toEqual(`<${link}>`);
   });
 
+  it('injects an update subscriptions link in the email', async () => {
+    const link = await updateSubscriptionsLink(email);
+    const result = await buildMessage('summary', { to: email });
+    const escapedLink = link.replace(/&/g, '&amp;').replace(/=/g, '&#x3D;');
+
+    expect(result.text).toContain(link);
+    expect(result.html).toContain(escapedLink);
+  });
+
   it('creates a valid unsubscribe link', async () => {
     const link = new URL((await unsubscribeLink(email)).replace('#/', ''));
+
+    expect(link.origin).toBe(process.env.FRONT_HOST);
+    expect(link.searchParams.get('signature')).toMatch(/^0x[a-f0-9]{130}$/gi);
+    expect(link.searchParams.get('email')).toBe(email);
+  });
+
+  it('creates a valid update subscriptions link', async () => {
+    const link = new URL((await updateSubscriptionsLink(email)).replace('#/', ''));
 
     expect(link.origin).toBe(process.env.FRONT_HOST);
     expect(link.searchParams.get('signature')).toMatch(/^0x[a-f0-9]{130}$/gi);


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

The link in the email footer is labeled `Unsubscribe`, but leads to a page where user can either update the email preferences, or unsubscribe

## 💊 Fixes / Solution

There should be 2 different links in the email footer:

- `Manage email preferences` : leads to a page where user can update his email preferences. Even with all options unchecked, this form will just disable email sending to this email address, without removing it from the database.
- `Unsubscribe` : leads to a page which will unsubscribe the user upon loading (bringing back the original unsubscribe page/workflow). This action will remove the email and all its associated addresses from the database.

## 🚧 Changes


- Add a new `Manage email preferences` link in the footer
- Minor fix to API endpoint, to ignore subscriptions params when checking the signature, when it is signed by the backend (and not user), since we do not ask for user signature when updating preferences from envelop-ui. We re-use the signature in the email's footer
- Tests update

## 🛠️ Tests

To be tested together with https://github.com/snapshot-labs/envelop-ui/pull/8

See the PR from envelop-ui above for test instructions
