### PR TITLE
chore(deps-dev): update to typescript 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
     "start-server-and-test": "^2.0.0",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.0",
-    "typescript": "<5"
+    "typescript": "^5.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5383,12 +5383,7 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@<5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
-
-"typescript@^4.6.4 || ^5.0.0":
+"typescript@^4.6.4 || ^5.0.0", typescript@^5.0.0:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
   integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Typescript is currently locked to version < 5, due to Jest lack of support. Jest was the only dependencies preventing us from upgrading to v5.

## 💊 Fixes / Solution

Jest now support typescript 5, since 29.1.0 (merged via https://github.com/snapshot-labs/envelop/pull/84), so we can now safely update to typescript 5

## 🚧 Changes

- Change the required version in `package.json`, to install typescript `^5.0.0`

## 🛠️ Tests

Run `yarn test` and `yarn test:e2e`. They should run without any warnings about unsupported typescript 5.