### PR TITLE
feat: return JSON RPC formatted 404 error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ app.use('/', rpc);
 app.use('/', preview);
 app.use('/', send);
 
-app.use((req, res) => {
+app.use((_, res) => {
   rpcError(res, 'RECORD_NOT_FOUND', '');
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import rpc from './rpc';
 import preview from './preview';
 import send from './preview/send';
 import { start as startQueue, shutdown as shutdownQueue } from './queues';
+import { rpcError } from './helpers/utils';
 
 const app = express();
 const PORT = process.env.PORT || 3006;
@@ -26,6 +27,10 @@ app.use(cors({ maxAge: 86400 }));
 app.use('/', rpc);
 app.use('/', preview);
 app.use('/', send);
+
+app.use((req, res) => {
+  rpcError(res, 'RECORD_NOT_FOUND', '');
+});
 
 const server = app.listen(PORT, () => console.log(`[http] Listening at http://localhost:${PORT}`));
 


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Error caught and throw by the app are formatted using JSON RPC.
Express default 404 error (for non-existing routes) are formatted using HTML.

Currently, 404 errors are returned in both JSON RPC and HTML format. Errors response should always use the same format, for consistency, and avoid parsing error from caller.

## 💊 Fixes / Solution

Default 404 Error responses from express should follow the JSON RPC format, like the rest of the endpoint.

## 🚧 Changes

- Add catch-all routes, to always return the page not found error using JSON RPC

## 🛠️ Tests

- Visit `localhost:3006/test`
- It should return a 404 error, JSON RPC formatted