### PR TITLE
fix: fix incorrect webhook auth header name

### DIFF
--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -80,7 +80,7 @@ router.post('/webhook', async (req, res) => {
   const event = body.event.toString();
   const id = body.id.toString().replace('proposal/', '');
 
-  if (req.headers['authenticate'] !== `${process.env.WEBHOOK_AUTH_TOKEN || ''}`) {
+  if (req.headers['Authentication'] !== `${process.env.WEBHOOK_AUTH_TOKEN || ''}`) {
     return rpcError(res, 'UNAUTHORIZED', id);
   }
 


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Header keyname for checking the webhook authentication key is incorrect

## 💊 Fixes / Solution

Change the header keyname to the correct one

## 🚧 Changes

- Rename key from `authenticate` to `Authentication`

## 🛠️ Tests

- Nothing