### PR TITLE
feat: return subscriber state

### DIFF
--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -110,6 +110,10 @@ router.post('/subscriber', async (req, res) => {
 
     return res.json(result);
   } catch (e: any) {
+    if (e.message === 'RECORD_NOT_FOUND') {
+      return res.json({ status: 'NOT_SUBSCRIBED' });
+    }
+
     console.log(e);
     return rpcError(res, e, address);
   }

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -7,7 +7,8 @@ import {
   rpcError,
   rpcSuccess,
   isValidEmail,
-  getAddressSubscriptions
+  getSubscriber,
+  obfuscateEmail
 } from './helpers/utils';
 import { verifySubscribe, verifyUnsubscribe, verifyVerify, verifyUpdate } from './sign';
 import { queueSubscribe, queueProposalActivity } from './queues';
@@ -104,7 +105,10 @@ router.post('/subscriber', async (req, res) => {
   const { address } = req.body;
 
   try {
-    return res.json(await getAddressSubscriptions(address));
+    const result = await getSubscriber(address);
+    result.email = obfuscateEmail(result.email);
+
+    return res.json(result);
   } catch (e: any) {
     console.log(e);
     return rpcError(res, e, address);

--- a/test/e2e/subscriber.test.ts
+++ b/test/e2e/subscriber.test.ts
@@ -77,12 +77,13 @@ describe('POST subscriber', () => {
   });
 
   describe('when the address does not exist', () => {
-    it('returns a 404 error', async () => {
+    it('returns a NOT_SUBSCRIBED state', async () => {
       const response = await request(process.env.HOST)
         .post('/subscriber')
         .send({ address: 'test' });
 
-      expect(response.statusCode).toBe(404);
+      expect(response.statusCode).toBe(200);
+      expect(response.body.status).toEqual('NOT_SUBSCRIBED');
     });
   });
 });

--- a/test/e2e/subscriber.test.ts
+++ b/test/e2e/subscriber.test.ts
@@ -7,13 +7,15 @@ describe('POST subscriber', () => {
   const email = 'test-subscribe@test.com';
   const address = '0xDBDd4c5473692Fa0490bfF6AAbf1181f29Ca851e';
   const addressB = '0x54C8b17E5c46B97d25498205182e0382234B2532';
+  const notVerifiedAddress = '0xc766c83C362E6D1Da8151F6aB588de7C79d03B8d';
 
   beforeAll(async () => {
     await Promise.all(
       [
         [+new Date() / 1e3, `a${email}`, address, JSON.stringify(['summary']), 0],
         [+new Date() / 1e3, email, address, JSON.stringify(['summary']), +new Date() / 1e3],
-        [+new Date() / 1e3, `b${email}`, addressB, null, +new Date() / 1e3]
+        [+new Date() / 1e3, `b${email}`, addressB, null, +new Date() / 1e3],
+        [+new Date() / 1e3, `c${email}`, notVerifiedAddress, null, 0]
       ].map(async data => {
         await db.queryAsync(
           'INSERT INTO subscribers (created, email, address, subscriptions, verified) VALUES (?, ?, ?, ?, ?)',
@@ -29,11 +31,18 @@ describe('POST subscriber', () => {
   });
 
   describe('when the address exists', () => {
-    it('returns a list of subscriptions for the verified email', async () => {
-      const response = await request(process.env.HOST).post('/subscriber').send({ address });
+    it('returns a 200 response', async () => {
+      const response = await request(process.env.HOST)
+        .post('/subscriber')
+        .send({ address: addressB });
 
       expect(response.statusCode).toBe(200);
-      expect(response.body).toEqual(['summary']);
+    });
+
+    it('returns a list of subscriptions', async () => {
+      const response = await request(process.env.HOST).post('/subscriber').send({ address });
+
+      expect(response.body.subscriptions).toEqual(['summary']);
     });
 
     it('returns the default list if the subscriptions list is empty', async () => {
@@ -41,8 +50,29 @@ describe('POST subscriber', () => {
         .post('/subscriber')
         .send({ address: addressB });
 
-      expect(response.statusCode).toBe(200);
-      expect(response.body).toEqual(SUBSCRIPTION_TYPE);
+      expect(response.body.subscriptions).toEqual(SUBSCRIPTION_TYPE);
+    });
+
+    it('returns an obfuscated version of the email', async () => {
+      const response = await request(process.env.HOST)
+        .post('/subscriber')
+        .send({ address: address });
+
+      expect(response.body.email).toEqual('te************@test.com');
+    });
+
+    it('returns a VEFIFIED state if the email is verified', async () => {
+      const response = await request(process.env.HOST).post('/subscriber').send({ address });
+
+      expect(response.body.status).toEqual('VERIFIED');
+    });
+
+    it('returns a UNVERIFIED state if the email is not verified', async () => {
+      const response = await request(process.env.HOST)
+        .post('/subscriber')
+        .send({ address: notVerifiedAddress });
+
+      expect(response.body.status).toEqual('UNVERIFIED');
     });
   });
 

--- a/test/unit/helpers/utils.test.ts
+++ b/test/unit/helpers/utils.test.ts
@@ -1,4 +1,4 @@
-import { isValidEmail, sanitizeSubscriptions } from '../../../src/helpers/utils';
+import { isValidEmail, obfuscateEmail, sanitizeSubscriptions } from '../../../src/helpers/utils';
 
 describe('utils', () => {
   describe('isvalidEmail', () => {
@@ -124,6 +124,14 @@ describe('utils', () => {
     it('always returns an array', () => {
       expect(sanitizeSubscriptions([])).toEqual([]);
       expect(sanitizeSubscriptions(['invalid'])).toEqual([]);
+    });
+  });
+
+  describe('obfuscateEmail()', () => {
+    it('returns an obfuscated version of the email', () => {
+      expect(obfuscateEmail('a@test.com')).toEqual('a@test.com');
+      expect(obfuscateEmail('ab@test.com')).toEqual('ab@test.com');
+      expect(obfuscateEmail('abcd@test.com')).toEqual('ab**@test.com');
     });
   });
 });


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Current subscriptions status are `subscribed` and `not subscribed`, and there is no status for email pending verification. 

## 💊 Fixes / Solution

Fix #63

Add a new `UNVERIFIED` status, when pending for an address subscriptions.

## 🚧 Changes

**BREAKING CHANGES**

- Update the `subscriber` endpoint, to return a subscriber object, instead of just an array of subscriptions

New returned response will look like: 

```
{
  state: 'VERIFIED',
  email: 'wa****@email.com',
  subscriptions: ['summary']
}
```

When email is verified, return state `VERIFIED`
When email is pending verification, return state `UNVERIFIED`
When email does not exist, return HTTP 404 status code

`email` field will be obfuscated, and will show only the first 2 characters before `@`

## 🛠️ Tests

- Send a POST request to `subscriber`: ` curl -X POST localhost:3006/subscriber -H "Content-Type: application/json" -d '{"address": "0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3"}'` (replace the `address` field with a value from your test database)