### PR TITLE
fix: fix webhook auth header detection

### DIFF
--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -77,10 +77,10 @@ router.post('/', async (req, res) => {
 
 router.post('/webhook', async (req, res) => {
   const body = req.body || {};
-  const event = body.event.toString();
-  const id = body.id.toString().replace('proposal/', '');
+  const event = body.event?.toString() ?? '';
+  const id = body.id?.toString().replace('proposal/', '') ?? '';
 
-  if (req.headers['Authentication'] !== `${process.env.WEBHOOK_AUTH_TOKEN || ''}`) {
+  if (req.headers['authentication'] !== `${process.env.WEBHOOK_AUTH_TOKEN || ''}`) {
     return rpcError(res, 'UNAUTHORIZED', id);
   }
 


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Webhook authentication detection is failing.

## 💊 Fixes / Solution

Fix header detection to use the correct name, `fetch` auto downcase all header name.
Mirror PR of https://github.com/snapshot-labs/snapshot-sidekick/pull/64 by @ChaituVR 

## 🚧 Changes

- Use 'authencation' instead of `Authentication`, for the header key name
- Add some other fixes to prevent errors when webhook body is empty

## 🛠️ Tests

- Nothing