### PR TITLE
fix: send email to only users subscribed to the given email type

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "nodemon src/index.ts -e js,ts,hbs,json",
     "start": "node dist/src/index.js",
     "start:test": "dotenv -e test/.env.test yarn dev",
-    "test": "dotenv -e test/.env.test jest test/unit/",
+    "test": "dotenv -e test/.env.test jest test/unit/ test/integrations/",
     "test:e2e": "PORT=3030 start-server-and-test 'yarn start:test' 3030 'jest --runInBand test/e2e/'",
     "typecheck": "tsc --noEmit"
   },

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -131,13 +131,15 @@ export async function unsubscribe(email: string, address: string) {
   );
 }
 
-export async function getVerifiedSubscriptions(batchSize = 1000) {
+export async function getVerifiedSubscriptions(subscription: string, batchSize = 1000) {
   let page = 0;
   let results: SqlRow[] = [];
+  const sub = sanitizeSubscriptions(subscription)[0];
 
   while (true) {
     const result = await db.queryAsync(
-      'SELECT email, address FROM subscribers WHERE verified > 0 ORDER BY created LIMIT ? OFFSET ?',
+      'SELECT email, address, subscriptions FROM subscribers WHERE verified > 0 ' +
+        `AND JSON_CONTAINS(subscriptions, '"${sub}"') ORDER BY created LIMIT ? OFFSET ?`,
       [batchSize, page * batchSize]
     );
 

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -136,10 +136,14 @@ export async function getVerifiedSubscriptions(subscription: string, batchSize =
   let results: SqlRow[] = [];
   const sub = sanitizeSubscriptions(subscription)[0];
 
+  if (!sub) {
+    throw new Error('Invalid subscription type');
+  }
+
   while (true) {
     const result = await db.queryAsync(
       'SELECT email, address, subscriptions FROM subscribers WHERE verified > 0 ' +
-        `AND JSON_CONTAINS(subscriptions, ?) ORDER BY created LIMIT ? OFFSET ?`,
+        `AND JSON_CONTAINS(subscriptions, ?) OR subscriptions IS NULL ORDER BY created LIMIT ? OFFSET ?`,
       [JSON.stringify(sub), batchSize, page * batchSize]
     );
 

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -139,8 +139,8 @@ export async function getVerifiedSubscriptions(subscription: string, batchSize =
   while (true) {
     const result = await db.queryAsync(
       'SELECT email, address, subscriptions FROM subscribers WHERE verified > 0 ' +
-        `AND JSON_CONTAINS(subscriptions, '"${sub}"') ORDER BY created LIMIT ? OFFSET ?`,
-      [batchSize, page * batchSize]
+        `AND JSON_CONTAINS(subscriptions, ?) ORDER BY created LIMIT ? OFFSET ?`,
+      [JSON.stringify(sub), batchSize, page * batchSize]
     );
 
     if (result.length === 0) {

--- a/src/queues/processors/proposalFactory.ts
+++ b/src/queues/processors/proposalFactory.ts
@@ -20,8 +20,8 @@ function eventToTemplate(event: string) {
 /**
  * Return a list of email, for all subscribers following the given spaceId
  */
-async function getSubscribersEmailFollowingSpace(spaceId: string) {
-  const subscriberEntries = await getVerifiedSubscriptions();
+async function getSubscribersEmailFollowingSpace(templateId: string, spaceId: string) {
+  const subscriberEntries = await getVerifiedSubscriptions(templateId);
   const subscriberKeyValuePairs: Iterable<[string, string]> = subscriberEntries.map(row => [
     row.address as string,
     row.email as string
@@ -48,7 +48,7 @@ export default async (job: Job): Promise<number> => {
     return 0;
   }
 
-  const emails = await getSubscribersEmailFollowingSpace(proposal.space.id);
+  const emails = await getSubscribersEmailFollowingSpace(templateId, proposal.space.id);
   await mailerQueue.addBulk(
     emails.map(email => ({
       name: templateId,

--- a/src/queues/processors/scheduler.ts
+++ b/src/queues/processors/scheduler.ts
@@ -9,7 +9,7 @@ import type { Dayjs } from 'dayjs';
  * grouped by email
  */
 async function getGroupedSubscribers() {
-  const subscriberEntries = await getVerifiedSubscriptions();
+  const subscriberEntries = await getVerifiedSubscriptions('summary');
   const subscribers: Record<string, string[]> = {};
 
   subscriberEntries.map(subscriber => {

--- a/test/integrations/utils.test.ts
+++ b/test/integrations/utils.test.ts
@@ -1,0 +1,43 @@
+import db from '../../src/helpers/mysql';
+import { getVerifiedSubscriptions } from '../../src/helpers/utils';
+import { cleanupDb } from '../utils';
+
+describe('utils', () => {
+  describe('getVerifiedSubscriptions()', () => {
+    beforeAll(async () => {
+      const ts = +new Date() / 1e3;
+      await Promise.all(
+        [
+          [ts, ts, `a@test.com`, '0x1', JSON.stringify(['summary'])],
+          [ts, ts, 'b@test.com', '0x2', JSON.stringify(['summary', 'newProposal'])],
+          [ts, ts, `c@test.com`, '0x3', null],
+          [ts, ts, `d@test.com`, '0x4', JSON.stringify([])]
+        ].map(async data => {
+          await db.queryAsync(
+            'INSERT INTO subscribers (created, verified, email, address, subscriptions) VALUES (?, ?, ?, ?, ?)',
+            data
+          );
+        })
+      );
+    });
+
+    afterAll(async () => {
+      await cleanupDb();
+      await db.endAsync();
+    });
+
+    it.each([
+      ['summary', ['a@test.com', 'b@test.com', 'c@test.com']],
+      ['newProposal', ['b@test.com', 'c@test.com']]
+    ])('returns subscribers subscribed to the given type (%s)', async (title, results) => {
+      const summarySubscribers = await getVerifiedSubscriptions(title);
+      expect(summarySubscribers.map(s => s.email)).toEqual(results);
+    });
+
+    it('throws an error when the given subscription is invalid', () => {
+      expect(async () => {
+        await getVerifiedSubscriptions('test');
+      }).rejects.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

All emails are sent to all users, regardless of their subscription preferences

## 💊 Fixes / Solution

Fix #80 

Users should only receive email types they have subscribed to

## 🚧 Changes

- Add filter before sending each email type, to send it to only emails subscribed to the given email type

## 🛠️ Tests

- Currently hard to test, only way know is to console.log ` await getVerifiedSubscriptions('summary');` somewhere in your code (and change the args to other email type), and see that it returns the correct database row. Requires your test DB to be populated with some test data.

More robusts tests will come later