### PR TITLE
fix: fix missing layout in proposal emails

### DIFF
--- a/src/templates/closedProposal/html.hbs
+++ b/src/templates/closedProposal/html.hbs
@@ -1,4 +1,4 @@
-{{#> layout}}
+{{#> layout.html}}
   <table role="presentation">
     <tbody>
       <tr>
@@ -53,4 +53,4 @@
       </tr>
     </tbody>
   </table>
-{{/layout}}
+{{/layout.html}}

--- a/src/templates/closedProposal/text.hbs
+++ b/src/templates/closedProposal/text.hbs
@@ -1,3 +1,4 @@
+{{#> layout.text}}
 {{proposal.title}} (CLOSED)
 ==================================
 {{proposal.link}}
@@ -14,3 +15,4 @@ Results ({{formattedVotesCount}} total votes)
 {{/each}}
 
 View full detailed results on: {{proposal.link}}
+{{/layout.text}}

--- a/src/templates/newProposal/html.hbs
+++ b/src/templates/newProposal/html.hbs
@@ -1,4 +1,4 @@
-{{#> layout}}
+{{#> layout.html}}
   <table role="presentation">
     <tbody>
       <tr>
@@ -65,4 +65,4 @@
       </tr>
     </tbody>
   </table>
-{{/layout}}
+{{/layout.html}}

--- a/src/templates/newProposal/text.hbs
+++ b/src/templates/newProposal/text.hbs
@@ -1,3 +1,4 @@
+{{#> layout.text}}
 {{proposal.title}}
 ==================================
 {{proposal.link}}
@@ -15,3 +16,4 @@ Cast you votes
 {{/each}}
 
 To vote, visit: {{proposal.link}}
+{{/layout.text}}


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

New and closed proposal emails are missing the layout wrapper

## 💊 Fixes / Solution

Fix #117

## 🚧 Changes

- Fix the invalid call to layout partial in html templates
- Fix the missing layout call in text templates

## 🛠️ Tests

- Use the `http://localhost:3006/preview/closedProposal?id=0x88583c43b196ec86cee45345611b582108f1d6933ab688a7cae992a6baa552a6` and `http://localhost:3006/preview/closedProposal?id=0x88583c43b196ec86cee45345611b582108f1d6933ab688a7cae992a6baa552a6`. 
- Check that the header logo and footer links are present