### PR TITLE
chore: fix missing redis instance on CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -3,8 +3,18 @@ on: [push]
 jobs:
   build-test:
     runs-on: ubuntu-20.04
+    services:
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     env:
       DATABASE_URL: 'mysql://root:root@127.0.0.1:3306/envelop_test'
+      REDIS_HOST: 127.0.0.1
+      REDIS_PORT: 6379
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Redis instance is missing on CI

## 💊 Fixes / Solution

Install redis instance on CI

## 🚧 Changes

- Add redis service to github workflow

## 🛠️ Tests

- Nothing to do