### PR TITLE
fix: fix missing `salt` in email verification link

### DIFF
--- a/scripts/send-subscribe.ts
+++ b/scripts/send-subscribe.ts
@@ -4,14 +4,14 @@ import subscribe from '../src/queues/processors/subscribe';
 
 async function main() {
   if (process.argv.length < 3) {
-    console.error(`Usage: yarn ts-node scripts/send-subscribe.ts [EMAIL] [ADDRESS]`);
+    console.error(`Usage: yarn ts-node scripts/send-subscribe.ts [EMAIL] [ADDRESS] [SALT]`);
     return process.exit(1);
   }
-  const [, , email, address] = process.argv;
+  const [, , email, address, salt] = process.argv;
 
   return await subscribe({
     name: '',
-    data: { email, address }
+    data: { email, address, salt }
   } as Job);
 }
 

--- a/src/queues/index.ts
+++ b/src/queues/index.ts
@@ -52,7 +52,7 @@ export function queueScheduler(options: Queue.JobOptions = {}) {
   return scheduleQueue.add({}, options);
 }
 
-export function queueSubscribe(email: string, address: string, salt: number) {
+export function queueSubscribe(email: string, address: string, salt: string) {
   return mailerQueue.add('subscribe', { email, address, salt });
 }
 

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -38,7 +38,7 @@ router.post('/', async (req, res) => {
       if (verifySubscribe(params.email, params.address, params.signature)) {
         const subscriber = await subscribe(params.email, params.address);
         if (subscriber) {
-          queueSubscribe(subscriber.email, subscriber.address, `${subscriber.created}`);
+          queueSubscribe(subscriber.email, subscriber.address, subscriber.created.toString());
         }
         return rpcSuccess(res, 'OK', id);
       }

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -38,7 +38,7 @@ router.post('/', async (req, res) => {
       if (verifySubscribe(params.email, params.address, params.signature)) {
         const subscriber = await subscribe(params.email, params.address);
         if (subscriber) {
-          queueSubscribe(subscriber.email, subscriber.address, subscriber.created);
+          queueSubscribe(subscriber.email, subscriber.address, `${subscriber.created}`);
         }
         return rpcSuccess(res, 'OK', id);
       }

--- a/src/templates/subscribe/index.ts
+++ b/src/templates/subscribe/index.ts
@@ -6,7 +6,8 @@ export default async function prepare(params: TemplatePrepareParams) {
   const verifyLink = `${process.env.FRONT_HOST}/#/verify?${new URLSearchParams({
     signature: await signVerify(params.to, params.address, params.salt),
     email: params.to,
-    address: params.address
+    address: params.address,
+    salt: params.salt
   }).toString()}`;
 
   return buildMessage('subscribe', { ...params, verifyLink });

--- a/test/e2e/verify.test.ts
+++ b/test/e2e/verify.test.ts
@@ -17,7 +17,7 @@ describe('POST verify', () => {
       params: {
         email,
         address,
-        salt: `${timestamp}`,
+        salt: timestamp.toString(),
         signature: signature || (await signVerify(email, address, timestamp))
       }
     };

--- a/test/e2e/verify.test.ts
+++ b/test/e2e/verify.test.ts
@@ -17,7 +17,7 @@ describe('POST verify', () => {
       params: {
         email,
         address,
-        salt: timestamp,
+        salt: `${timestamp}`,
         signature: signature || (await signVerify(email, address, timestamp))
       }
     };


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Email verification link is missing the `salt` params, making all verification link fail

## 💊 Fixes / Solution

Fix #126 

Add the missing `salt` params to verification link

## 🚧 Changes

- Inject the missing `salt` link to all verification links

## 🛠️ Tests

- Go to `/preview/verify`. The verify link should contains the `salt` param
- You can also test sending yourself an email with the `send-subscribe` scripts. 

If you want to test the whole workflow with envelop-ui, test with the PR https://github.com/snapshot-labs/envelop-ui/pull/17