### PR TITLE
fix(UI): fix content not taking up the full width

### DIFF
--- a/src/templates/closedProposal/html.hbs
+++ b/src/templates/closedProposal/html.hbs
@@ -1,5 +1,5 @@
 {{#> layout.html}}
-  <table role="presentation">
+  <table role="presentation" width="100%">
     <tbody>
       <tr>
         <td>

--- a/src/templates/newProposal/html.hbs
+++ b/src/templates/newProposal/html.hbs
@@ -1,5 +1,5 @@
 {{#> layout.html}}
-  <table role="presentation">
+  <table role="presentation" width="100%">
     <tbody>
       <tr>
         <td>

--- a/src/templates/partials/layout.html.hbs
+++ b/src/templates/partials/layout.html.hbs
@@ -35,7 +35,7 @@
     <div class="container" role="article" aria-roledescription="email" aria-label="{{subject}}" lang="en" dir="ltr" style="font-size:medium; font-size:max(16px, 1em);">
       <div class="content">
         <div class="content-body">
-          <table role="presentation">
+          <table role="presentation" width="100%">
             <tbody>
               <tr>
                 <td>
@@ -54,7 +54,7 @@
       </div>
       <div class="content">
         <div class="content-footer">
-          <table role="presentation">
+          <table role="presentation" width="100%">
             <tr>
               <td>
                 {{#if unsubscribeLink}}

--- a/src/templates/partials/proposals.html.hbs
+++ b/src/templates/partials/proposals.html.hbs
@@ -1,4 +1,4 @@
-<table role="presentation" class="space-block">
+<table role="presentation" class="space-block w-100">
   <tbody>
     <tr>
       <td>

--- a/src/templates/subscribe/html.hbs
+++ b/src/templates/subscribe/html.hbs
@@ -1,5 +1,5 @@
 {{#> layout.html}}
-  <table tole="presentation">
+  <table tole="presentation" width="100%">
     <tbody>
       <tr>
         <td class="content-body-heading">

--- a/src/templates/summary/html.hbs
+++ b/src/templates/summary/html.hbs
@@ -1,5 +1,5 @@
 {{#> layout.html}}
-  <table role="presentation">
+  <table role="presentation" width="100%">
     <tbody>
       <tr>
         <td class="content-body-heading">


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

New and Closed proposal emails are not taking the full width when there is not enough content

## 💊 Fixes / Solution

Fix the issues

## 🚧 Changes

- Add a width="100%" to all table element

## 🛠️ Tests

- Visit `http://localhost:3006/preview/newProposal?id=0x6fcbd2e1af981e9c19baa62d83183e521caeb361ca7f96441552ddcb38188d61`. The email content should take the full width