### PR TITLE
fix(UI): fix READ MORE link in truncated proposal not working

### DIFF
--- a/src/templates/closedProposal/index.ts
+++ b/src/templates/closedProposal/index.ts
@@ -40,6 +40,6 @@ export default async function prepare(params: TemplatePrepareParams) {
     winningChoiceName: results[winningChoiceIndex].name,
     winningChoicePercentage: results[winningChoiceIndex].progress,
     proposalTextBody: `${truncatedBody}${isTruncated ? ` [...]` : ''}`,
-    proposalHtmlBody: formatProposalHtmlBody(truncatedBody, isTruncated)
+    proposalHtmlBody: formatProposalHtmlBody(proposal, truncatedBody, isTruncated)
   });
 }

--- a/src/templates/newProposal/index.ts
+++ b/src/templates/newProposal/index.ts
@@ -20,6 +20,6 @@ export default async function prepare(params: TemplatePrepareParams) {
     formattedStartDate: new Date(proposal.start * 1000).toUTCString(),
     formattedEndDate: new Date(proposal.end * 1000).toUTCString(),
     proposalTextBody: `${truncatedBody}${isTruncated ? ` [...]` : ''}`,
-    proposalHtmlBody: formatProposalHtmlBody(truncatedBody, isTruncated)
+    proposalHtmlBody: formatProposalHtmlBody(proposal, truncatedBody, isTruncated)
   });
 }

--- a/src/templates/utils.ts
+++ b/src/templates/utils.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import Handlebars from 'handlebars';
 import { marked } from 'marked';
 import { signUnsubscribe, signUpdate } from '../sign';
+import { Proposal } from '../helpers/snapshot';
 
 export async function unsubscribeLink(email: string) {
   return `${process.env.FRONT_HOST}/#/unsubscribe?${new URLSearchParams({
@@ -41,13 +42,13 @@ export function loadPartials() {
     });
 }
 
-export function formatProposalHtmlBody(body: string, isTruncated: boolean) {
+export function formatProposalHtmlBody(proposal: Proposal, body: string, isTruncated: boolean) {
   return (
     marked
       .parse(`${body}${isTruncated ? `...` : ''}`)
       .replace(/<img[^>]*>/g, '')
       .replace(/(\n)(\s*[^<])/g, '<br/>$2') +
-    (isTruncated ? '<a href="${proposal.link}">(read more)</a>' : '')
+    (isTruncated ? `<a href="${proposal.link}">(read more)</a>` : '')
   );
 }
 


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

The READ MORE link in truncated proposal body is not valid, it shows `${proposal.link}` instead

## 💊 Fixes / Solution

Fix the link

## 🚧 Changes

- Fix the invalid link

## 🛠️ Tests

- Visit `http://localhost:3006/preview/newProposal?id=0x6b703b90d3cd1f82f7c176fc2e566a2bb79e8eb6618a568b52a4f29cb2f8d57b`. The READ MORE link should redirect to the proposal page