### PR TITLE
fix: fix email obfuscation not working with special characters

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -189,7 +189,7 @@ export async function getModerationList() {
 }
 
 export function obfuscateEmail(email: string) {
-  return email.replace(/(\w{2})([\w.-]+)@([\w.]+\w)/, (_, a, b, c) => {
+  return email.replace(/([\w\._\-+]{2})(.+)@([\w.]+\w)/, (_, a, b, c) => {
     return `${a}${'*'.repeat(b.length)}@${c}`;
   });
 }

--- a/test/unit/helpers/utils.test.ts
+++ b/test/unit/helpers/utils.test.ts
@@ -130,8 +130,13 @@ describe('utils', () => {
   describe('obfuscateEmail()', () => {
     it('returns an obfuscated version of the email', () => {
       expect(obfuscateEmail('a@test.com')).toEqual('a@test.com');
-      expect(obfuscateEmail('ab@test.com')).toEqual('ab@test.com');
+      expect(obfuscateEmail('a1@test.com')).toEqual('a1@test.com');
+      expect(obfuscateEmail('a+@test.com')).toEqual('a+@test.com');
+      expect(obfuscateEmail('a.a.a@test.com')).toEqual('a.***@test.com');
       expect(obfuscateEmail('abcd@test.com')).toEqual('ab**@test.com');
+      expect(obfuscateEmail('abcd+t3st@test.com')).toEqual('ab*******@test.com');
+      expect(obfuscateEmail('abcd-test@test.com')).toEqual('ab*******@test.com');
+      expect(obfuscateEmail('abcd.test@test.com')).toEqual('ab*******@test.com');
     });
   });
 });


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Email address with special characters are not obfuscating

## 💊 Fixes / Solution

Fix #128 

## 🚧 Changes

- Fix the regex to take not ignore special characters

## 🛠️ Tests

- Run `yarn test`. See `test/unit/helpers/utils.test.ts`