### PR TITLE
fix: disable link in proposal body

### DIFF
--- a/src/helpers/snapshot.ts
+++ b/src/helpers/snapshot.ts
@@ -96,6 +96,7 @@ export type Proposal = {
   scores?: number[];
   scores_total?: number;
   shortBody?: string;
+  htmlShortBody?: string;
   voted?: boolean;
   votes?: number;
 };

--- a/src/templates/partials/proposals.html.hbs
+++ b/src/templates/partials/proposals.html.hbs
@@ -15,7 +15,7 @@
         {{#each proposals}}
           <a href="{{link}}" target="_blank" class="proposal-title">{{title}}</a>
           <p class="proposal-body">
-            {{shortBody}}
+            {{{htmlShortBody}}}
             {{#if voted}}
               <small class="has-voted">You voted in this proposal</small>
             {{/if}}

--- a/src/templates/summary/index.ts
+++ b/src/templates/summary/index.ts
@@ -35,12 +35,14 @@ export async function getGroupedProposals(addresses: string[], startDate: Date, 
   const votedProposals = votes.map(vote => vote.proposal.id);
   proposals.forEach(proposal => {
     const sanitizedBody = removeMd(proposal.body);
-
     proposal.shortBody = (
       sanitizedBody.length > MAX_SHORT_BODY_LENGTH
         ? `${sanitizedBody.slice(0, MAX_SHORT_BODY_LENGTH)}…`
         : sanitizedBody
     ).replace(/\r?\n|\r/g, ' ');
+    proposal.htmlShortBody = proposal.shortBody
+      .replace(/https+:\/\//g, '')
+      .replace(/(\/|\.)/g, '<span>$1</span>');
 
     proposal.voted = votedProposals.includes(proposal.id);
   });

--- a/src/templates/utils.ts
+++ b/src/templates/utils.ts
@@ -42,11 +42,10 @@ export function loadPartials() {
 }
 
 export function formatProposalHtmlBody(body: string, isTruncated: boolean) {
+  marked.use({ breaks: true });
+
   return (
-    marked
-      .parse(`${body}${isTruncated ? `...` : ''}`)
-      .replace(/<img[^>]*>/g, '')
-      .replace(/(\n)(\s*[^<])/g, '<br/>$2') +
+    marked.parse(`${body}${isTruncated ? `...` : ''}`).replace(/<img[^>]*>/g, '') +
     (isTruncated ? '<a href="${proposal.link}">(read more)</a>' : '')
   );
 }

--- a/src/templates/utils.ts
+++ b/src/templates/utils.ts
@@ -45,7 +45,10 @@ export function formatProposalHtmlBody(body: string, isTruncated: boolean) {
   marked.use({ breaks: true });
 
   return (
-    marked.parse(`${body}${isTruncated ? `...` : ''}`).replace(/<img[^>]*>/g, '') +
+    marked
+      .parse(`${body}${isTruncated ? `...` : ''}`)
+      .replace(/<img[^>]*>/g, '')
+      .replace(/<a[^>]*>(.*?)<\/a>/g, '$1') +
     (isTruncated ? '<a href="${proposal.link}">(read more)</a>' : '')
   );
 }

--- a/src/templates/utils.ts
+++ b/src/templates/utils.ts
@@ -48,7 +48,9 @@ export function formatProposalHtmlBody(body: string, isTruncated: boolean) {
     marked
       .parse(`${body}${isTruncated ? `...` : ''}`)
       .replace(/<img[^>]*>/g, '')
-      .replace(/<a[^>]*>(.*?)<\/a>/g, '$1') +
+      .replace(/<a[^>]*>(.*?)<\/a>/g, '$1')
+      .replace(/https+:\/\//g, '')
+      .replace(/(\/|\.)/g, '<span>$1</span>') +
     (isTruncated ? '<a href="${proposal.link}">(read more)</a>' : '')
   );
 }


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

In new/closed proposal email, body markdown is parsed as HTML, and links are rendered inside a `a` tag.
This create danger, as we may start scammy links to user via email, and flag our email address as dangerous. 

Links lookalike are also auto converted to links by gmail, and gmail auto create attachment for links to google drive

## 💊 Fixes / Solution

Fix #73

Remove and disable all links in proposal body

## 🚧 Changes

- Remove all `< a href >` tag from proposal body. only show the title, and not the url
- For link-like test (https://a.com/b.pdf), inject invisible `span` inside it, to prevent Gmail and other inbox to parse and auto-detect them as link.

## 🛠️ Tests

- Visit `http://localhost:3006/preview/newProposal?id=0x950dac4d5715b8aa8eab29c484b1c9dd0eed161141262b0425874f65be4d9f8e` . Proposal body should not contains any links. 
- Visit `http://localhost:3006/preview/summary?id=0xF78108c9BBaF466dd96BE41be728Fe3220b37119`, there should be no link in proposal body. Also send an email to yourself, to confirm that your email provider does not auto parse link anymore. 