### PR TITLE
fix: fix incorrect regex

### DIFF
--- a/src/templates/newProposal/html.hbs
+++ b/src/templates/newProposal/html.hbs
@@ -60,7 +60,7 @@
       </tr>
       <tr>
         <td style="padding-top: .5em; padding-bottom: 1em">
-          Voting close on {{formattedEndDate}}
+          Voting closes on {{formattedEndDate}}
         </td>
       </tr>
     </tbody>

--- a/src/templates/summary/index.ts
+++ b/src/templates/summary/index.ts
@@ -42,7 +42,7 @@ export async function getGroupedProposals(addresses: string[], startDate: Date, 
     ).replace(/\r?\n|\r/g, ' ');
     proposal.htmlShortBody = proposal.shortBody
       .replace(/https?:\/\//g, '')
-      .replace(/(\/|\.)/g, '<span>$1</span>');
+      .replace(/([^<](\/|\.))/g, '<span>$1</span>');
 
     proposal.voted = votedProposals.includes(proposal.id);
   });

--- a/src/templates/utils.ts
+++ b/src/templates/utils.ts
@@ -51,7 +51,7 @@ export function formatProposalHtmlBody(proposal: Proposal, body: string, isTrunc
       .replace(/<img[^>]*>/g, '')
       .replace(/<a[^>]*>(.*?)<\/a>/g, '$1')
       .replace(/https?:\/\//g, '')
-      .replace(/(\/|\.)/g, '<span>$1</span>') +
+      .replace(/([^<](\/|\.))/g, '<span>$1</span>') +
     (isTruncated ? '<a href="${proposal.link}">(read more)</a>' : '')
   );
 }


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

A regex rule is incorrect, and causing issues by invalidating all html closing tags (`</`)

<img width="633" alt="image" src="https://github.com/snapshot-labs/envelop/assets/495709/f5ff87f7-c3fe-42f8-bda7-fc9e040f6a22">

## 💊 Fixes / Solution

Fix the regex

## 🚧 Changes

- Fix the regex rule, by ignoring `</` when matching `/`
- Fix some grammar

## 🛠️ Tests

- open `http://localhost:3006/preview/newProposal?id=0x9171495a9dea3c604784a3261168e615f85b727092fa185bc5ad2226567ac0e5`
- proposal body should be formatted correctly, without displaying closing html as plain text