### PR TITLE
fix: fix missing string interpolation

### DIFF
--- a/src/templates/utils.ts
+++ b/src/templates/utils.ts
@@ -52,7 +52,7 @@ export function formatProposalHtmlBody(proposal: Proposal, body: string, isTrunc
       .replace(/<a[^>]*>(.*?)<\/a>/g, '$1')
       .replace(/https?:\/\//g, '')
       .replace(/([^<](\/|\.))/g, '<span>$1</span>') +
-    (isTruncated ? '<a href="${proposal.link}">(read more)</a>' : '')
+    (isTruncated ? `<a href="${proposal.link}">(read more)</a>` : '')
   );
 }
 


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

READ MORE link in new/closed proposal email body is not working

## 💊 Fixes / Solution

Use backtick instead of quote

## 🚧 Changes

- Fix string not being interpolated

## 🛠️ Tests

- Open `http://localhost:3006/preview/newProposal?id=0x6b703b90d3cd1f82f7c176fc2e566a2bb79e8eb6618a568b52a4f29cb2f8d57b`
- The READ MORE link should lead to the proposal page in snapshot website