### PR TITLE
fix: stop returning subscriber email

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -172,7 +172,6 @@ export async function getSubscriber(address: string) {
 
   return {
     status: (subscriber.verified as number) > 0 ? 'VERIFIED' : 'UNVERIFIED',
-    email: subscriber.email as string,
     subscriptions: !subscriber.subscriptions
       ? SUBSCRIPTION_TYPE
       : JSON.parse(subscriber.subscriptions as string)
@@ -192,10 +191,4 @@ export async function getModerationList() {
   const response = await fetch(`${process.env.SIDEKICK_URL || 'https://sh5.co'}/api/moderation`);
 
   return response.json();
-}
-
-export function obfuscateEmail(email: string) {
-  return email.replace(/([\w\._\-+]{2})(.+)@([\w.]+\w)/, (_, a, b, c) => {
-    return `${a}${'*'.repeat(b.length)}@${c}`;
-  });
 }

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -7,8 +7,7 @@ import {
   rpcError,
   rpcSuccess,
   isValidEmail,
-  getSubscriber,
-  obfuscateEmail
+  getSubscriber
 } from './helpers/utils';
 import { verifySubscribe, verifyUnsubscribe, verifyVerify, verifyUpdate } from './sign';
 import { queueSubscribe, queueProposalActivity } from './queues';
@@ -115,7 +114,6 @@ router.post('/subscriber', async (req, res) => {
 
   try {
     const result = await getSubscriber(address);
-    result.email = obfuscateEmail(result.email);
 
     return res.json(result);
   } catch (e: any) {

--- a/test/e2e/subscriber.test.ts
+++ b/test/e2e/subscriber.test.ts
@@ -53,14 +53,6 @@ describe('POST subscriber', () => {
       expect(response.body.subscriptions).toEqual(SUBSCRIPTION_TYPE);
     });
 
-    it('returns an obfuscated version of the email', async () => {
-      const response = await request(process.env.HOST)
-        .post('/subscriber')
-        .send({ address: address });
-
-      expect(response.body.email).toEqual('te************@test.com');
-    });
-
     it('returns a VEFIFIED state if the email is verified', async () => {
       const response = await request(process.env.HOST).post('/subscriber').send({ address });
 

--- a/test/unit/helpers/utils.test.ts
+++ b/test/unit/helpers/utils.test.ts
@@ -1,4 +1,4 @@
-import { isValidEmail, obfuscateEmail, sanitizeSubscriptions } from '../../../src/helpers/utils';
+import { isValidEmail, sanitizeSubscriptions } from '../../../src/helpers/utils';
 
 describe('utils', () => {
   describe('isvalidEmail', () => {
@@ -124,19 +124,6 @@ describe('utils', () => {
     it('always returns an array', () => {
       expect(sanitizeSubscriptions([])).toEqual([]);
       expect(sanitizeSubscriptions(['invalid'])).toEqual([]);
-    });
-  });
-
-  describe('obfuscateEmail()', () => {
-    it('returns an obfuscated version of the email', () => {
-      expect(obfuscateEmail('a@test.com')).toEqual('a@test.com');
-      expect(obfuscateEmail('a1@test.com')).toEqual('a1@test.com');
-      expect(obfuscateEmail('a+@test.com')).toEqual('a+@test.com');
-      expect(obfuscateEmail('a.a.a@test.com')).toEqual('a.***@test.com');
-      expect(obfuscateEmail('abcd@test.com')).toEqual('ab**@test.com');
-      expect(obfuscateEmail('abcd+t3st@test.com')).toEqual('ab*******@test.com');
-      expect(obfuscateEmail('abcd-test@test.com')).toEqual('ab*******@test.com');
-      expect(obfuscateEmail('abcd.test@test.com')).toEqual('ab*******@test.com');
     });
   });
 });


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

We return an obfuscated version of the subscriber email

## 💊 Fixes / Solution

Stop returning it for privacy reason

## 🚧 Changes

- Stop returning the subscriber email

## 🛠️ Tests

- Send ` curl -X POST localhost:3006/subscriber --header "Authenticate: 00" -H "Content-Type: application/json" -d '{"address": "0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3"}'` with an wallet address existing in your test database.
- It should return a JSON object, with `status` and `subscriptions` keys, without `email`