### PR TITLE
fix: find verified user first

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -161,7 +161,7 @@ export async function getVerifiedSubscriptions(subscription: string, batchSize =
 export async function getSubscriber(address: string) {
   const subscriber = (
     await db.queryAsync(
-      'SELECT email, verified, subscriptions from subscribers WHERE address = ? ORDER BY created DESC, verified DESC LIMIT 1',
+      'SELECT email, verified, subscriptions from subscribers WHERE address = ? ORDER BY verified DESC, created DESC LIMIT 1',
       [address]
     )
   )[0];


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

the `/subscriber` endpoint is now returning the first found match, sorted by created DESC. When there is duplicate and last one is not verified, it will return the not verified one instead of the verified one.

## 💊 Fixes / Solution

When there is duplicated, prioritize the verified row first

## 🚧 Changes

- Change the query sort order, to return `verified` user in priority

## 🛠️ Tests

- 2 rows with same address but different email in the DB
- Verify the oldest
- `/subscriber` should return the verified row, instead of the most recent unverified row