### PR TITLE
chore: send test coverage report to codecov

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -32,3 +32,7 @@ jobs:
       - run: yarn build
       - run: yarn test
       - run: yarn test:e2e
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,6 +6,7 @@
 export default {
   clearMocks: true,
   collectCoverage: true,
+  collectCoverageFrom: ['./src/**'],
   coverageDirectory: 'coverage',
   coverageProvider: 'v8',
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/src/index.js",
     "start:test": "dotenv -e test/.env.test yarn dev",
     "test": "dotenv -e test/.env.test jest test/unit/ test/integrations/",
-    "test:e2e": "PORT=3030 start-server-and-test 'yarn start:test' 3030 'jest --runInBand test/e2e/'",
+    "test:e2e": "PORT=3030 start-server-and-test 'yarn start:test' 3030 'jest --runInBand --collectCoverage=false test/e2e/'",
     "typecheck": "tsc --noEmit"
   },
   "eslintConfig": {


### PR DESCRIPTION
- Disable test coverage for e2e tests
- Code coverage should be relative to the whole project, and not only from tested files
- Send test coverage report to codecov