### PR TITLE
feat: add introduction text to email

### DIFF
--- a/src/templates/closedProposal/html.hbs
+++ b/src/templates/closedProposal/html.hbs
@@ -2,6 +2,9 @@
   <table role="presentation" width="100%">
     <tbody>
       <tr>
+        <td class="introduction">A proposal's voting period has ended on {{proposal.space.name}}</td>
+      </tr>
+      <tr>
         <td>
           <table role="presentation" width="100%">
             <tr class="content-body-preheading">

--- a/src/templates/closedProposal/text.hbs
+++ b/src/templates/closedProposal/text.hbs
@@ -1,3 +1,6 @@
+A proposal's voting period has ended on {{proposal.space.name}}
+
+==================================
 {{#> layout.text}}
 {{proposal.title}} (CLOSED)
 ==================================

--- a/src/templates/newProposal/html.hbs
+++ b/src/templates/newProposal/html.hbs
@@ -2,6 +2,9 @@
   <table role="presentation" width="100%">
     <tbody>
       <tr>
+        <td class="introduction">A new proposal has been submitted on {{proposal.space.name}}</td>
+      </tr>
+      <tr>
         <td>
           <table role="presentation" width="100%">
             <tr class="content-body-preheading">

--- a/src/templates/newProposal/text.hbs
+++ b/src/templates/newProposal/text.hbs
@@ -1,15 +1,18 @@
+A new proposal has been submitted on {{proposal.space.name}}
+
+==================================
 {{#> layout.text}}
 {{proposal.title}}
 ==================================
 {{proposal.link}}
 
-Submitted by {{proposal.author}} on {{proposal.space.name}}
+Submitted by {{proposal.author}}
 Voting period from {{formattedStartDate}} to {{formattedEndDate}}
 
 {{proposalTextBody}}
 
 --------------
-Cast you votes
+Cast your votes
 --------------
 {{#each proposal.choices}}
 [ ] {{this}}

--- a/src/templates/styles/proposal-activity.scss
+++ b/src/templates/styles/proposal-activity.scss
@@ -4,6 +4,20 @@
   }
 }
 
+.content-body-preheading {
+  td {
+    padding-top: 1em;
+  }
+}
+
+.introduction {
+  font-size: 125%;
+  padding-bottom: 1em;
+  margin-bottom: 1em;
+  border-bottom: 1px solid transparent;
+  border-color: $border-color;
+}
+
 .proposal-fullbody {
   font-size: 1.1em;
   line-height: 1.4em;
@@ -148,5 +162,9 @@
     hr {
       border-color: $border-color;
     }
+  }
+
+  .introduction {
+    border-color: $border-color;
   }
 }


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

As requested by @less, to have some kind of context about the email purpose, add a new introduction text explaining the purpose of the email

## 💊 Fixes / Solution

Fix #158 

## 🚧 Changes

- Add new introduction text to new/closed proposal emails

## 🛠️ Tests

- Observe the change in the email previewer
- `http://localhost:3006/preview/newProposal?id=0x88583c43b196ec86cee45345611b582108f1d6933ab688a7cae992a6baa552a6`
- `http://localhost:3006/preview/closedProposal?id=0x88583c43b196ec86cee45345611b582108f1d6933ab688a7cae992a6baa552a6`