### PR TITLE
fix: bump the new proposal delay to up to 2h

### DIFF
--- a/src/queues/processors/proposalFactory.ts
+++ b/src/queues/processors/proposalFactory.ts
@@ -4,7 +4,7 @@ import { Proposal, getFollows, getProposal } from '../../helpers/snapshot';
 import { getModerationList, getVerifiedSubscriptions } from '../../helpers/utils';
 import type { Job } from 'bull';
 
-const MAX_NEW_PROPOSAL_DELAY = 2 * 60 * 60 * 1000; // 2 hours
+export const MAX_NEW_PROPOSAL_DELAY = 2 * 60 * 60 * 1000; // 2 hours
 
 function eventToTemplate(event: string) {
   switch (event) {
@@ -39,12 +39,12 @@ async function getSubscribersEmailFollowingSpace(templateId: string, spaceId: st
   return results;
 }
 
-function proposalDelay(proposal: Proposal) {
+export function proposalDelay(proposal: Proposal) {
   let newProposalDelay = MAX_NEW_PROPOSAL_DELAY;
   const sendTimestamp = +new Date() + newProposalDelay;
 
   // Prevent sending new proposal email after it closes
-  if (proposal.end >= sendTimestamp) {
+  if (proposal.end <= sendTimestamp) {
     newProposalDelay = (proposal.end - +new Date()) * 0.75;
   }
 

--- a/src/queues/processors/proposalFactory.ts
+++ b/src/queues/processors/proposalFactory.ts
@@ -45,7 +45,7 @@ function proposalDelay(proposal: Proposal) {
 
   // Prevent sending new proposal email after it closes
   if (proposal.end >= sendTimestamp) {
-    newProposalDelay = Math.floor((proposal.end - sendTimestamp) / 2);
+    newProposalDelay = (proposal.end - +new Date()) * 0.75;
   }
 
   return newProposalDelay;

--- a/src/queues/processors/proposalFactory.ts
+++ b/src/queues/processors/proposalFactory.ts
@@ -1,10 +1,10 @@
 import chunk from 'lodash.chunk';
 import { mailerQueue } from '../index';
-import { getFollows, getProposal } from '../../helpers/snapshot';
+import { Proposal, getFollows, getProposal } from '../../helpers/snapshot';
 import { getModerationList, getVerifiedSubscriptions } from '../../helpers/utils';
 import type { Job } from 'bull';
 
-const NEW_PROPOSAL_DELAY = 600000; // 10 minutes
+const MAX_NEW_PROPOSAL_DELAY = 2 * 60 * 60 * 1000; // 2 hours
 
 function eventToTemplate(event: string) {
   switch (event) {
@@ -39,6 +39,18 @@ async function getSubscribersEmailFollowingSpace(templateId: string, spaceId: st
   return results;
 }
 
+function proposalDelay(proposal: Proposal) {
+  let newProposalDelay = MAX_NEW_PROPOSAL_DELAY;
+  const sendTimestamp = +new Date() + newProposalDelay;
+
+  // Prevent sending new proposal email after it closes
+  if (proposal.end >= sendTimestamp) {
+    newProposalDelay = Math.floor((proposal.end - sendTimestamp) / 2);
+  }
+
+  return newProposalDelay;
+}
+
 export default async (job: Job): Promise<number> => {
   const { event, id } = job.data;
   const templateId = eventToTemplate(event);
@@ -63,7 +75,7 @@ export default async (job: Job): Promise<number> => {
       },
       opts: {
         jobId: `${templateId}-${email}-${id}`,
-        delay: templateId === 'newProposal' ? NEW_PROPOSAL_DELAY : 0
+        delay: templateId === 'newProposal' ? proposalDelay(proposal) : 0
       }
     }))
   );

--- a/test/unit/queues/processors/proposalFactory.test.ts
+++ b/test/unit/queues/processors/proposalFactory.test.ts
@@ -1,0 +1,24 @@
+import {
+  MAX_NEW_PROPOSAL_DELAY,
+  proposalDelay
+} from '../../../../src/queues/processors/proposalFactory';
+
+describe('proposalFactory', () => {
+  describe('proposalDelay()', () => {
+    it('returns MAX_NEW_PROPOSAL_DELAY if proposal is ending after the delay', () => {
+      const proposal = {
+        end: +new Date() + MAX_NEW_PROPOSAL_DELAY * 10
+      };
+      const result = proposalDelay(proposal as any);
+      expect(result).toBe(MAX_NEW_PROPOSAL_DELAY);
+    });
+
+    it('returns voting period * 0.75 if proposal end before delay', () => {
+      const proposal = {
+        end: +new Date() + 1000
+      };
+      const result = proposalDelay(proposal as any);
+      expect(result).toBe(750);
+    });
+  });
+});


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

The current 10min delay between new proposal creation and email sending is too short, and deos not allow enough time for spam detection.

## 💊 Fixes / Solution

Bump the delay for up to 2hours.
In case the proposal voting period is < 2 hours, will delay by ¾ of the voting period.

Fix #157 

## 🚧 Changes

- Increase the new proposal email sending delay from 10min to 2h
- In case the voting period is < 2h, delay is voting period * 0.75

## 🛠️ Tests

- Read the tests for the file
- Trust the test ?
