### PR TITLE
fix: fix failing tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -17,5 +17,6 @@ export default {
   testEnvironment: 'jest-environment-node-single-context',
   globalSetup: '<rootDir>/test/setup.ts',
   //setupFilesAfterEnv: ['<rootDir>src/setupTests.ts'],
-  moduleFileExtensions: ['js', 'ts']
+  moduleFileExtensions: ['js', 'ts'],
+  testPathIgnorePatterns: ['dist/']
 };

--- a/src/queues/processors/proposalFactory.ts
+++ b/src/queues/processors/proposalFactory.ts
@@ -2,7 +2,7 @@ import chunk from 'lodash.chunk';
 import { mailerQueue } from '../index';
 import { getFollows, getProposal } from '../../helpers/snapshot';
 import { getModerationList, getVerifiedSubscriptions } from '../../helpers/utils';
-import { newProposalDelay } from '../utils';
+import { proposalDelay } from '../utils';
 import type { Job } from 'bull';
 
 function eventToTemplate(event: string) {
@@ -62,7 +62,7 @@ export default async (job: Job): Promise<number> => {
       },
       opts: {
         jobId: `${templateId}-${email}-${id}`,
-        delay: templateId === 'newProposal' ? newProposalDelay(proposal) : 0
+        delay: templateId === 'newProposal' ? proposalDelay(proposal) : 0
       }
     }))
   );

--- a/src/queues/utils.ts
+++ b/src/queues/utils.ts
@@ -1,15 +1,15 @@
 import type { Proposal } from '../helpers/snapshot';
 
-export const MAX_NEW_PROPOSAL_DELAY = 2 * 60 * 60 * 1000; // 2 hours
+export const MAX_PROPOSAL_DELAY = 2 * 60 * 60 * 1000; // 2 hours
 
-export function newProposalDelay(proposal: Proposal) {
-  let newProposalDelay = MAX_NEW_PROPOSAL_DELAY;
-  const sendTimestamp = +new Date() + newProposalDelay;
+export function proposalDelay(proposal: Proposal) {
+  let proposalDelay = MAX_PROPOSAL_DELAY;
+  const sendTimestamp = +new Date() + proposalDelay;
 
   // Prevent sending new proposal email after it closes
   if (proposal.end <= sendTimestamp) {
-    newProposalDelay = (proposal.end - +new Date()) * 0.75;
+    proposalDelay = (proposal.end - +new Date()) * 0.75;
   }
 
-  return newProposalDelay;
+  return proposalDelay;
 }

--- a/src/queues/utils.ts
+++ b/src/queues/utils.ts
@@ -1,0 +1,15 @@
+import type { Proposal } from '../helpers/snapshot';
+
+export const MAX_NEW_PROPOSAL_DELAY = 2 * 60 * 60 * 1000; // 2 hours
+
+export function newProposalDelay(proposal: Proposal) {
+  let newProposalDelay = MAX_NEW_PROPOSAL_DELAY;
+  const sendTimestamp = +new Date() + newProposalDelay;
+
+  // Prevent sending new proposal email after it closes
+  if (proposal.end <= sendTimestamp) {
+    newProposalDelay = (proposal.end - +new Date()) * 0.75;
+  }
+
+  return newProposalDelay;
+}

--- a/test/unit/queues/utils.test.ts
+++ b/test/unit/queues/utils.test.ts
@@ -1,20 +1,20 @@
-import { MAX_NEW_PROPOSAL_DELAY, newProposalDelay } from '../../../src/queues/utils';
+import { MAX_PROPOSAL_DELAY, proposalDelay } from '../../../src/queues/utils';
 
 describe('proposalFactory', () => {
   describe('proposalDelay()', () => {
-    it('returns MAX_NEW_PROPOSAL_DELAY if proposal is ending after the delay', () => {
+    it('returns MAX_PROPOSAL_DELAY if proposal is ending after the delay', () => {
       const proposal = {
-        end: +new Date() + MAX_NEW_PROPOSAL_DELAY * 10
+        end: +new Date() + MAX_PROPOSAL_DELAY * 10
       };
-      const result = newProposalDelay(proposal as any);
-      expect(result).toBe(MAX_NEW_PROPOSAL_DELAY);
+      const result = proposalDelay(proposal as any);
+      expect(result).toBe(MAX_PROPOSAL_DELAY);
     });
 
     it('returns voting period * 0.75 if proposal end before delay', () => {
       const proposal = {
         end: +new Date() + 1000
       };
-      const result = newProposalDelay(proposal as any);
+      const result = proposalDelay(proposal as any);
       expect(result).toBe(750);
     });
   });

--- a/test/unit/queues/utils.test.ts
+++ b/test/unit/queues/utils.test.ts
@@ -1,7 +1,4 @@
-import {
-  MAX_NEW_PROPOSAL_DELAY,
-  proposalDelay
-} from '../../../../src/queues/processors/proposalFactory';
+import { MAX_NEW_PROPOSAL_DELAY, newProposalDelay } from '../../../src/queues/utils';
 
 describe('proposalFactory', () => {
   describe('proposalDelay()', () => {
@@ -9,7 +6,7 @@ describe('proposalFactory', () => {
       const proposal = {
         end: +new Date() + MAX_NEW_PROPOSAL_DELAY * 10
       };
-      const result = proposalDelay(proposal as any);
+      const result = newProposalDelay(proposal as any);
       expect(result).toBe(MAX_NEW_PROPOSAL_DELAY);
     });
 
@@ -17,7 +14,7 @@ describe('proposalFactory', () => {
       const proposal = {
         end: +new Date() + 1000
       };
-      const result = proposalDelay(proposal as any);
+      const result = newProposalDelay(proposal as any);
       expect(result).toBe(750);
     });
   });


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Tests for proposalFactory were failing, due to dependencies to redis. The tested function by themselves does not depend on redis, and thus are failing for unrelated reasons (connection to redis from bull)

## 💊 Fixes / Solution

Extract the tested function in another utils.ts file

## 🚧 Changes

- Extract the `newProposalDelay()` into its own helper file, isolating it from any side effects from the queue system
- Ignore `dist` folder from test path

## 🛠️ Tests

- Run `yarn test`
- The test should not fail anymore on the CI (was working fine on local)

Failing tests for queue system are due to the way Bull is connecting to redis on CI. Will be 
 fixed by #67 
