### PR TITLE
chore: enable sentry only on production

### DIFF
--- a/src/helpers/sentry.ts
+++ b/src/helpers/sentry.ts
@@ -3,6 +3,10 @@ import type { Express } from 'express';
 import { rpcError } from './utils';
 
 export function initLogger(app: Express) {
+  if (process.env.NODE_ENV !== 'production') {
+    return;
+  }
+
   Sentry.init({
     dsn: process.env.SENTRY_DSN,
     integrations: [

--- a/src/helpers/sentry.ts
+++ b/src/helpers/sentry.ts
@@ -23,6 +23,10 @@ export function initLogger(app: Express) {
 }
 
 export function fallbackLogger(app: Express) {
+  if (process.env.NODE_ENV !== 'production') {
+    return;
+  }
+
   app.use(Sentry.Handlers.errorHandler());
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -32,5 +36,9 @@ export function fallbackLogger(app: Express) {
 }
 
 export function capture(e: any) {
+  if (process.env.NODE_ENV !== 'production') {
+    return console.error(e);
+  }
+
   Sentry.captureException(e);
 }


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Sentry is always enabled, as long as DSN is set, and may send errors when developing on local.

## 💊 Fixes / Solution

- Enable sentry logger only on production

## 🚧 Changes

- Add a condition to enable sentry only on prod, by checking `NODE_ENV`
- `NODE_ENV` have been set to `production` on the prod server

## 🛠️ Tests

- N/A