### PR TITLE
fix(UI): prevent weird breaking on small screen

### DIFF
--- a/src/templates/styles/styles.scss
+++ b/src/templates/styles/styles.scss
@@ -162,6 +162,7 @@ table {
   line-height: 24px;
   text-transform: capitalize;
   color: #fff;
+  word-break: keep-all;
 }
 
 .state-closed {

--- a/src/templates/styles/summary.scss
+++ b/src/templates/styles/summary.scss
@@ -33,6 +33,7 @@
   &-block {
     border: 1px solid $border-color;
     margin: 1em 0;
+    word-break: keep-all;
 
     width: 100%;
 


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Some text are broken on weird places

![Screenshot_20230720_094834_Gmail](https://github.com/snapshot-labs/envelop/assets/495709/8a9ebe80-2bff-4fbd-9751-1f4b1423b08d)


## 💊 Fixes / Solution

Disable word-break on some elements

## 🚧 Changes

- Disable word break on status badge
- Disable word break on summary stats block

## 🛠️ Tests

