### PR TITLE
fix: fix escaped characters

### DIFF
--- a/src/templates/closedProposal/text.hbs
+++ b/src/templates/closedProposal/text.hbs
@@ -1,4 +1,4 @@
-A proposal's voting period has ended on {{proposal.space.name}}
+A proposal's voting period has ended on {{{proposal.space.name}}}
 
 ==================================
 {{#> layout.text}}

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -33,7 +33,7 @@ const templates: Templates = {
     name: 'Proposal creation',
     description: 'Get informed when a new proposal is submitted in your followed spaces.',
     from: 'Snapshot <notify@snapshot.org>',
-    subject: '[{{proposal.space.name}}] New proposal: {{proposal.title}}',
+    subject: '[{{{proposal.space.name}}}] New proposal: {{proposal.title}}',
     text: fs.readFileSync('./src/templates/newProposal/text.hbs', 'utf-8'),
     preheader:
       'Voting period from {{formattedStartDate}} to {{formattedEndDate}} - ' +
@@ -45,7 +45,7 @@ const templates: Templates = {
     name: 'Proposal closure',
     description: 'Get informed when a proposal is closed in your followed spaces.',
     from: 'Snapshot <notify@snapshot.org>',
-    subject: '[{{proposal.space.name}}] Closed proposal: {{proposal.title}}',
+    subject: '[{{{proposal.space.name}}}] Closed proposal: {{proposal.title}}',
     text: fs.readFileSync('./src/templates/closedProposal/text.hbs', 'utf-8'),
     preheader:
       '{{winningChoiceName}} {{winningChoicePercentage}}% - ' +

--- a/src/templates/newProposal/text.hbs
+++ b/src/templates/newProposal/text.hbs
@@ -1,4 +1,4 @@
-A new proposal has been submitted on {{proposal.space.name}}
+A new proposal has been submitted on {{{proposal.space.name}}}
 
 ==================================
 {{#> layout.text}}


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Some characters in space title are escaped

![Screenshot_20230720_094834_Gmail](https://github.com/snapshot-labs/envelop/assets/495709/db40624d-dab8-4129-913f-b9f6a1a30a53)


## 💊 Fixes / Solution

Disable characters escaping on space name

Fix #181 

## 🚧 Changes

- Disable characters escaping on space name

## 🛠️ Tests

- Visit https://snapshot.org/#/daodungeon.eth/proposal/0x101a17d7d07c789778bb6342518f38700e9226bd9bdf7b7376416bb61eaccd38
- Space name should not be escape anymore