### PR TITLE
fix: use snapshot-metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@ethersproject/address": "^5.7.0",
     "@ethersproject/wallet": "^5.7.0",
     "@sendgrid/mail": "^7.7.0",
+    "@snapshot-labs/snapshot-metrics": "^1.0.0",
     "@snapshot-labs/snapshot-sentry": "^1.1.0",
     "bluebird": "^3.7.2",
     "bull": "^4.10.4",

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -1,4 +1,4 @@
-import init from '@snapshot-labs/snapshot-metrics';
+import init, { client } from '@snapshot-labs/snapshot-metrics';
 import db from './mysql';
 import { SUBSCRIPTION_TYPE } from '../templates';
 import { mailerQueue } from '../queues';
@@ -6,7 +6,6 @@ import type { Express } from 'express';
 
 export default function initMetrics(app: Express) {
   init(app, {
-    customMetrics,
     normalizedPath: [
       ['^/preview/.*', '/preview/#template'],
       ['^/send/.*', '/send/#template']
@@ -20,49 +19,47 @@ export default function initMetrics(app: Express) {
   });
 }
 
-async function customMetrics(client: any) {
-  new client.Gauge({
-    name: 'subscribers_per_status_count',
-    help: 'Number of subscribers per status',
-    labelNames: ['status'],
-    async collect() {
-      [
-        ['VERIFIED', 'verified > 0'],
-        ['UNVERIFIED', 'verified IS NULL']
-      ].forEach(async function callback(this: any, data: any) {
-        this.set(
-          { status: data[0] },
-          (await db.queryAsync(`SELECT count(*) as count FROM subscribers WHERE ${data[1]}`))[0]
-            .count as any
-        );
-      }, this);
-    }
-  });
+new client.Gauge({
+  name: 'subscribers_per_status_count',
+  help: 'Number of subscribers per status',
+  labelNames: ['status'],
+  async collect() {
+    [
+      ['VERIFIED', 'verified > 0'],
+      ['UNVERIFIED', 'verified IS NULL']
+    ].forEach(async function callback(this: any, data: any) {
+      this.set(
+        { status: data[0] },
+        (await db.queryAsync(`SELECT count(*) as count FROM subscribers WHERE ${data[1]}`))[0]
+          .count as any
+      );
+    }, this);
+  }
+});
 
-  new client.Gauge({
-    name: 'subscribers_per_subscription_count',
-    help: 'Number of subscribers per subscription type',
-    labelNames: ['type'],
-    async collect() {
-      SUBSCRIPTION_TYPE.forEach(async function callback(this: any, type) {
-        this.set(
-          { type },
-          (
-            await db.queryAsync(
-              `SELECT count(*) as count FROM subscribers WHERE verified > 0 AND JSON_CONTAINS(subscriptions, ?) OR subscriptions IS NULL`,
-              JSON.stringify([type])
-            )
-          )[0].count as any
-        );
-      }, this);
-    }
-  });
+new client.Gauge({
+  name: 'subscribers_per_subscription_count',
+  help: 'Number of subscribers per subscription type',
+  labelNames: ['type'],
+  async collect() {
+    SUBSCRIPTION_TYPE.forEach(async function callback(this: any, type) {
+      this.set(
+        { type },
+        (
+          await db.queryAsync(
+            `SELECT count(*) as count FROM subscribers WHERE verified > 0 AND JSON_CONTAINS(subscriptions, ?) OR subscriptions IS NULL`,
+            JSON.stringify([type])
+          )
+        )[0].count as any
+      );
+    }, this);
+  }
+});
 
-  new client.Gauge({
-    name: 'mailing_queued_jobs',
-    help: 'Number of emails in the queue, pending sending',
-    async collect() {
-      this.set(await mailerQueue.count());
-    }
-  });
-}
+new client.Gauge({
+  name: 'mailing_queued_jobs',
+  help: 'Number of emails in the queue, pending sending',
+  async collect() {
+    this.set(await mailerQueue.count());
+  }
+});

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -1,7 +1,7 @@
 import client from 'prom-client';
 import promBundle from 'express-prom-bundle';
 import db from './mysql';
-import type { Express } from 'express';
+import type { Express, Request } from 'express';
 import { SUBSCRIPTION_TYPE } from '../templates';
 import { mailerQueue } from '../queues';
 
@@ -18,7 +18,19 @@ export default function initMetrics(app: Express) {
       normalizePath: [
         ['^/preview/.*', '/preview/#template'],
         ['^/send/.*', '/send/#template']
-      ]
+      ],
+      bypass: {
+        onRequest: (req: Request) => {
+          const whitelist = [
+            /^\/(preview|send)\/.*$/,
+            /^\/$/,
+            /^\/(webhook|subscriber|subscriptionsList)$/,
+            /^\/images\/.*\.png$/
+          ];
+
+          return !whitelist.some(regex => req.path.match(regex));
+        }
+      }
     })
   );
 }

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -14,7 +14,11 @@ export default function initMetrics(app: Express) {
       includePath: true,
       promClient: {
         collectDefaultMetrics: {}
-      }
+      },
+      normalizePath: [
+        ['^/preview/.*', '/preview/#template'],
+        ['^/send/.*', '/send/#template']
+      ]
     })
   );
 }

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -57,7 +57,7 @@ new client.Gauge({
 });
 
 new client.Gauge({
-  name: 'mailing_queued_jobs',
+  name: 'mailing_queued_jobs_count',
   help: 'Number of emails in the queue, pending sending',
   async collect() {
     this.set(await mailerQueue.count());

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,9 +14,6 @@ const app = express();
 const PORT = process.env.PORT || 3006;
 
 initLogger(app);
-
-// Exclude favicon request from metrics by defining it before
-app.get('/favicon.*', (req, res) => res.status(204));
 initMetrics(app);
 
 startQueue();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1272,6 +1272,14 @@
   resolved "https://registry.yarnpkg.com/@snapshot-labs/prettier-config/-/prettier-config-0.1.0-beta.7.tgz#c8e07e7e9baabee245020a72ac05835b65139823"
   integrity sha512-k/FUf4VWhwLFUmKuWs2mNvmPe691hqhvCJuujD4TfbIivWysmL1TqthwfdQUrQEAQUqVQ2ZKEiGkbufp5J27eQ==
 
+"@snapshot-labs/snapshot-metrics@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot-metrics/-/snapshot-metrics-1.0.0.tgz#1f88a6aacc81f639f7059c153b53c550934cd3b3"
+  integrity sha512-6T8a2NX6Qo6zVAoNIWV8eSJCukCynI/HCLp37VZTzX8jwU/ahGsiDTQC3I/MDus+LDB+8pI5nju33NwM8Q7n2g==
+  dependencies:
+    express-prom-bundle "^6.6.0"
+    prom-client "^14.2.0"
+
 "@snapshot-labs/snapshot-sentry@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot-sentry/-/snapshot-sentry-1.1.0.tgz#b357d4789ffd287f90fb70e7f0b207b47627cf24"


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

- The metrics lib is logging every http requests. This is creating a log of noises, as a webserver is getting a lot of invalid requests, spam, bot, etc..., and the http request metrics  is reporting a lot of unrelated data.
- Theres' a few repetition among repository for the metrics logic setup.

## 💊 Fixes / Solution

- The metrics for the http requests should only include routes defined in the express app
- Migrate the bootstrapping and metrics setup to snapshot-metrics

## 🚧 Changes

- add a whitelist of routes to be tracked by the metrics system
- normalize path, so `/send/1` and `/send/2` are tracked as a single `/send/ID`
- Use snapshot-metrics to handle metrics setup
- Rename `queued_mailing_jobs` metrics to `mailing_queued_jobs_count` to follow naming convention

## 🛠️ Tests

- Go to `http://localhost:3006/subscriptionsList`
- Go to `http://localhost:3006/metrics`
- the `subscriptionsList` should appear in the `http_request_duration_seconds_bucket` metric
- Go to `http://localhost:3006/robots.txt`
- Go to `http://localhost:3006/metrics`
- It should not appear in the metrics