### PR TITLE
fix: filter out proposals from non-verified spaces

### DIFF
--- a/src/helpers/snapshot.ts
+++ b/src/helpers/snapshot.ts
@@ -21,6 +21,7 @@ const FOLLOWS_QUERY = gql`
       follower
       space {
         id
+        verified
       }
     }
   }
@@ -42,6 +43,7 @@ const PROPOSALS_QUERY = gql`
       space {
         id
         name
+        verified
       }
     }
   }
@@ -65,6 +67,7 @@ const PROPOSAL_QUERY = gql`
       space {
         id
         name
+        verified
       }
     }
   }
@@ -81,7 +84,7 @@ const VOTES_QUERY = gql`
   }
 `;
 
-export type Space = { id: string; name?: string };
+export type Space = { id: string; name?: string; verified: boolean };
 export type Follow = { space: Space; follower: string };
 export type Proposal = {
   id: string;

--- a/src/queues/processors/proposalFactory.ts
+++ b/src/queues/processors/proposalFactory.ts
@@ -48,7 +48,7 @@ export default async (job: Job): Promise<number> => {
 
   const proposal = await getProposal(id);
 
-  if (!proposal) {
+  if (!proposal || !proposal.space.verified) {
     return 0;
   }
 

--- a/src/templates/closedProposal/index.ts
+++ b/src/templates/closedProposal/index.ts
@@ -6,7 +6,7 @@ import type { TemplatePrepareParams } from '../../../types';
 export default async function prepare(params: TemplatePrepareParams) {
   const proposal = await getProposal(params.id);
 
-  if (!proposal) {
+  if (!proposal || !proposal.space.verified) {
     throw new Error('Proposal not found');
   }
 

--- a/src/templates/newProposal/index.ts
+++ b/src/templates/newProposal/index.ts
@@ -6,7 +6,7 @@ import type { TemplatePrepareParams } from '../../../types';
 export default async function prepare(params: TemplatePrepareParams) {
   const proposal = await getProposal(params.id);
 
-  if (!proposal) {
+  if (!proposal || !proposal.space.verified) {
     throw new Error('Proposal not found');
   }
 

--- a/src/templates/summary/index.ts
+++ b/src/templates/summary/index.ts
@@ -17,8 +17,8 @@ export async function getGroupedProposals(addresses: string[], startDate: Date, 
 
   const follows = await getFollows(addresses);
   const trustedSpaces = follows
-    .map(follow => follow.space.id)
-    .filter((spaceId: string) => !flaggedSpaces.includes(spaceId));
+    .filter(follow => follow.space.verified && !flaggedSpaces.includes(follow.space.id))
+    .map(follow => follow.space.id);
   const allProposals = await getProposals(trustedSpaces, startDate, endDate);
   const proposals = allProposals.filter(proposal => !flaggedProposals.includes(proposal.id));
   const votes = await getVotes(

--- a/test/fixtures/proposals.ts
+++ b/test/fixtures/proposals.ts
@@ -9,7 +9,7 @@ export const proposals: Proposal[] = [
     end: 1678243620,
     state: 'active',
     link: 'https://snapshot.org/#/spaceone.eth/proposal/0xda05f86b3d7305e5a31b9f23a02c3625edcae5e73ac717a99fa2bf36bcdd0144',
-    space: { id: 'spaceone.eth', name: 'TestDAO' }
+    space: { id: 'spaceone.eth', name: 'TestDAO', verified: true }
   },
   {
     id: '0x2',
@@ -19,7 +19,7 @@ export const proposals: Proposal[] = [
     end: 1678243620,
     state: 'active',
     link: 'https://snapshot.org/#/spaceone.eth/proposal/0xda05f86b3d7305e5a31b9f23a02c3625edcae5e73ac717a99fa2bf36bcdd0144',
-    space: { id: 'spaceone.eth', name: 'TestDAO' }
+    space: { id: 'spaceone.eth', name: 'TestDAO', verified: true }
   },
   {
     id: '0x3',
@@ -29,7 +29,7 @@ export const proposals: Proposal[] = [
     end: 1678243620,
     state: 'active',
     link: 'https://snapshot.org/#/spacetwo.eth/proposal/0xda05f86b3d7305e5a31b9f23a02c3625edcae5e73ac717a99fa2bf36bcdd0144',
-    space: { id: 'spacetwo.eth', name: 'TestDAO' }
+    space: { id: 'spacetwo.eth', name: 'TestDAO', verified: true }
   },
   {
     id: '0x4',
@@ -39,7 +39,7 @@ export const proposals: Proposal[] = [
     end: 1678243620,
     state: 'pending',
     link: 'https://snapshot.org/#/testsnap.eth/proposal/0xda05f86b3d7305e5a31b9f23a02c3625edcae5e73ac717a99fa2bf36bcdd0144',
-    space: { id: 'testsnap.eth', name: 'TestDAO' }
+    space: { id: 'testsnap.eth', name: 'TestDAO', verified: true }
   },
   {
     id: '0x5',
@@ -49,7 +49,7 @@ export const proposals: Proposal[] = [
     end: 1678243620,
     state: 'closed',
     link: 'https://snapshot.org/#/testsnap.eth/proposal/0xda05f86b3d7305e5a31b9f23a02c3625edcae5e73ac717a99fa2bf36bcdd0144',
-    space: { id: 'testsnap.eth', name: 'TestDAO' }
+    space: { id: 'testsnap.eth', name: 'TestDAO', verified: true }
   }
 ];
 


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Emails are filtering out only flagged proposal/spaces, and may include low quality content from non-verified spaces.

## 💊 Fixes / Solution

Filtering out proposals from non-verified spaces

Fix #196 

## 🚧 Changes

- Add a filter to only process proposals from verified spaces

## 🛠️ Tests

- Go to `http://localhost:3006/preview/newProposal?id=0x77ceed96fe9868b0f6df55fa88b96d9bf32494f78f990ebd6bf32bdaab40e7a6`
- It should return an error, since the given proposal ID is from a non-verified space
- Try passing an ID from a verified space, it should succeed 


- Join a few non-verified space with your account
- Go to http://localhost:3006/preview/summary?id=[YOUR-ETH-ADDRESS]
- It should only shows proposals from verified spaces