### PR TITLE
fix: fix summary returning all spaces when there's no verified spaces

### DIFF
--- a/src/templates/summary/index.ts
+++ b/src/templates/summary/index.ts
@@ -19,6 +19,11 @@ export async function getGroupedProposals(addresses: string[], startDate: Date, 
   const trustedSpaces = follows
     .filter(follow => follow.space.verified && !flaggedSpaces.includes(follow.space.id))
     .map(follow => follow.space.id);
+
+  if (trustedSpaces.length === 0) {
+    return [];
+  }
+
   const allProposals = await getProposals(trustedSpaces, startDate, endDate);
   const proposals = allProposals.filter(proposal => !flaggedProposals.includes(proposal.id));
   const votes = await getVotes(


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

We pass a list of spaces to the `getProposals` query, fetching all proposals for the summary email. 

The issue is that when that list is empty, `getProposals` will return all spaces, instead of nothing. 

## 💊 Fixes / Solution

Should return early by returning an empty array when there's no activities from the verified spaces followed by the user.

## 🚧 Changes

- return an empty array as soon as possible

## 🛠️ Tests

before fix: 

- Go to `http://localhost:3000/preview/summary`
- It should show a summary with only unverified spaces

after fix:

- Go to `http://localhost:3000/preview/summary` 
- Should show nothing