### PR TITLE
fix: add tracker to proposal link

### DIFF
--- a/src/templates/closedProposal/index.ts
+++ b/src/templates/closedProposal/index.ts
@@ -1,6 +1,6 @@
 import buildMessage from '../builder';
 import { getProposal } from '../../helpers/snapshot';
-import { formatProposalHtmlBody } from '../utils';
+import { formatProposalHtmlBody, linkWithTracker } from '../utils';
 import type { TemplatePrepareParams } from '../../../types';
 
 export default async function prepare(params: TemplatePrepareParams) {
@@ -29,6 +29,7 @@ export default async function prepare(params: TemplatePrepareParams) {
     return b.progress - a.progress;
   });
   const winningChoiceIndex = results.findIndex(p => p.winning);
+  proposal.link = linkWithTracker(proposal.link);
 
   return buildMessage('closedProposal', {
     ...params,

--- a/src/templates/newProposal/index.ts
+++ b/src/templates/newProposal/index.ts
@@ -1,5 +1,5 @@
 import buildMessage from '../builder';
-import { formatProposalHtmlBody } from '../utils';
+import { formatProposalHtmlBody, linkWithTracker } from '../utils';
 import { getProposal } from '../../helpers/snapshot';
 import type { TemplatePrepareParams } from '../../../types';
 
@@ -13,6 +13,8 @@ export default async function prepare(params: TemplatePrepareParams) {
   const BODY_LENGTH = 1000;
   const truncatedBody = proposal.body.slice(0, BODY_LENGTH);
   const isTruncated = proposal.body.length > BODY_LENGTH;
+
+  proposal.link = linkWithTracker(proposal.link);
 
   return buildMessage('newProposal', {
     ...params,

--- a/src/templates/summary/index.ts
+++ b/src/templates/summary/index.ts
@@ -5,6 +5,7 @@ import buildMessage from '../builder';
 import constants from '../../helpers/constants.json';
 import type { TemplatePrepareParams } from '../../../types';
 import { getModerationList } from '../../helpers/utils';
+import { linkWithTracker } from '../utils';
 
 type ProposalStatus = 'pending' | 'active' | 'closed';
 type GroupedSpaces = { space: Space; proposals: Proposal[] };
@@ -50,6 +51,7 @@ export async function getGroupedProposals(addresses: string[], startDate: Date, 
       .replace(/([^<](\/|\.))/g, '<span>$1</span>');
 
     proposal.voted = votedProposals.includes(proposal.id);
+    proposal.link = linkWithTracker(proposal.link);
   });
 
   Object.keys(groupedProposals).forEach(status => {

--- a/src/templates/utils.ts
+++ b/src/templates/utils.ts
@@ -63,3 +63,10 @@ export function formatPreheader(text: string, maxLength = 150) {
 
   return text;
 }
+
+export function linkWithTracker(link: string) {
+  const _link = new URL(link);
+  _link.searchParams.set('app', 'envelop');
+
+  return _link.toString();
+}

--- a/test/unit/templates/utils.test.ts
+++ b/test/unit/templates/utils.test.ts
@@ -1,0 +1,29 @@
+import { linkWithTracker } from '../../../src/templates/utils';
+
+describe('utils', () => {
+  describe('linkWithTracker', () => {
+    describe('when the link does not have any query params', () => {
+      it('appends the tracker query params', () => {
+        expect(linkWithTracker('https://snapshot.org/test')).toEqual(
+          'https://snapshot.org/test?app=envelop'
+        );
+      });
+    });
+
+    describe('when the link have some query params', () => {
+      it('appends the tracker query params', () => {
+        expect(linkWithTracker('https://snapshot.org/test/?page=1')).toEqual(
+          'https://snapshot.org/test/?page=1&app=envelop'
+        );
+      });
+    });
+
+    describe('when the link have a query params with the same name', () => {
+      it('overwrite the tracker query params', () => {
+        expect(linkWithTracker('https://snapshot.org/test/?app=test')).toEqual(
+          'https://snapshot.org/test/?app=envelop'
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
Following this conversation https://discord.com/channels/955773041898573854/1090359266763874384/1148911823853207553 and fix #239 

This PR add a `?app=envelop` query params to all proposal links