### PR TITLE
chore: edit dependabot to only update org packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,6 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'daily'
+    allow:
+      - dependency-name: '@snapshot-labs/*'


### PR DESCRIPTION
This PR update dependabot config to:
- increase the update frequency to daily instead of weekly
- only update packages from @snapshot-labs 

To be inline with config from other repo
