### PR TITLE
fix: search params are added in middle of URL

### DIFF
--- a/src/templates/utils.ts
+++ b/src/templates/utils.ts
@@ -65,8 +65,5 @@ export function formatPreheader(text: string, maxLength = 150) {
 }
 
 export function linkWithTracker(link: string) {
-  const _link = new URL(link);
-  _link.searchParams.set('app', 'envelop');
-
-  return _link.toString();
+  return `${link}?app=envelop`;
 }

--- a/test/unit/templates/utils.test.ts
+++ b/test/unit/templates/utils.test.ts
@@ -9,21 +9,5 @@ describe('utils', () => {
         );
       });
     });
-
-    describe('when the link have some query params', () => {
-      it('appends the tracker query params', () => {
-        expect(linkWithTracker('https://snapshot.org/test/?page=1')).toEqual(
-          'https://snapshot.org/test/?page=1&app=envelop'
-        );
-      });
-    });
-
-    describe('when the link have a query params with the same name', () => {
-      it('overwrite the tracker query params', () => {
-        expect(linkWithTracker('https://snapshot.org/test/?app=test')).toEqual(
-          'https://snapshot.org/test/?app=envelop'
-        );
-      });
-    });
   });
 });


### PR DESCRIPTION
`new URL` making things complicated to just add `app` param



How to test:
 - open your console
 - Run
 ```js
function linkWithTracker(link) {
  const _link = new URL(link);
  _link.searchParams.set('app', 'envelop');

  return _link.toString();
}
linkWithTracker("https://snapshot.org/#/stgdao.eth/proposal/0x82586192cf58f438cfee7101afde68df11ab3be071a6f7c05d1a3e8506836ee2")
// https://snapshot.org/?app=envelop#/stgdao.eth/proposal/0x82586192cf58f438cfee7101afde68df11ab3be071a6f7c05d1a3e8506836ee2
```