### PR TITLE
chore: log more error details to sentry

### DIFF
--- a/src/helpers/mail.ts
+++ b/src/helpers/mail.ts
@@ -8,8 +8,8 @@ export async function send(msg: Message) {
   try {
     const result = await sgMail.send(msg);
     console.log('[mail] Email sent', result);
-  } catch (e) {
-    capture(e);
-    console.error('[mail] Email failed', e);
+  } catch (e: any) {
+    capture(e, { errors: e.response?.body?.errors });
+    console.error('[mail] Email failed', JSON.stringify(e));
   }
 }


### PR DESCRIPTION
On mail send error, the error object is logged as `[Array]` without details.

This PR improve the error logging, by logging the error object properly