### PR TITLE
fix: fix graphql query to follow new hub format

### DIFF
--- a/src/helpers/snapshot.ts
+++ b/src/helpers/snapshot.ts
@@ -53,7 +53,7 @@ const PROPOSALS_QUERY = gql`
 `;
 
 const PROPOSAL_QUERY = gql`
-  query Proposal($id: String) {
+  query Proposal($id: String!) {
     proposal(id: $id) {
       id
       body


### PR DESCRIPTION
Fix for new format introduced in https://github.com/snapshot-labs/snapshot-hub/pull/836