### PR TITLE
feat: add an index to the `verified` column in the database

### DIFF
--- a/src/helpers/schema.sql
+++ b/src/helpers/schema.sql
@@ -6,5 +6,6 @@ CREATE TABLE subscribers (
   verified BIGINT NOT NULL DEFAULT 0,
   PRIMARY KEY (email, address),
   UNIQUE KEY idx_address_email (address, email),
-  INDEX created (created)
+  INDEX created (created),
+  INDEX verified (verified)
 );


### PR DESCRIPTION
We have a few SQL using the `verified > 0` where filter.

Adding an index on this column will speed up the query

### TODO

Run the following query on prod db 

```sql
ALTER TABLE subscribers ADD INDEX verified (`verified`);
```