### PR TITLE
fix: add TTL to Bull queue jobs to prevent Redis OOM

### DIFF
--- a/src/queues/index.ts
+++ b/src/queues/index.ts
@@ -29,8 +29,8 @@ const opts = {
 };
 
 const defaultJobOptions = {
-  removeOnComplete: { age: 7 * 24 * 3600 },
-  removeOnFail: { age: 14 * 24 * 3600 }
+  removeOnComplete: { age: 7 * 24 * 3600, count: 10000 },
+  removeOnFail: { age: 14 * 24 * 3600, count: 5000 }
 };
 
 export const mailerQueue = new Queue('mailer', {

--- a/src/queues/index.ts
+++ b/src/queues/index.ts
@@ -28,9 +28,23 @@ const opts = {
   }
 };
 
-export const mailerQueue = new Queue('mailer', opts);
-export const scheduleQueue = new Queue('scheduler', opts);
-export const proposalActivityQueue = new Queue('proposal-activities', opts);
+const defaultJobOptions = {
+  removeOnComplete: { age: 7 * 24 * 3600 },
+  removeOnFail: { age: 14 * 24 * 3600 }
+};
+
+export const mailerQueue = new Queue('mailer', {
+  ...opts,
+  defaultJobOptions
+});
+export const scheduleQueue = new Queue('scheduler', {
+  ...opts,
+  defaultJobOptions
+});
+export const proposalActivityQueue = new Queue('proposal-activities', {
+  ...opts,
+  defaultJobOptions
+});
 
 mailerQueue.on('completed', job => {
   countSentEmails.inc({ type: job.name });


### PR DESCRIPTION
Fixes https://snapshot-labs.sentry.io/issues/7226584003/?project=4505459145703424&query=is%3Aunresolved&referrer=issue-stream

The Redis database was running out of memory, and not processing emails anymore.

An emergency cleanup was done manually, to free up some spaces (and fix the issue, preventing email sending). 

This PR will add a TTL to the redis objects, to prevent this issue in the future

## Summary

- Add `removeOnComplete` (7 days) and `removeOnFail` (14 days) to all Bull queues

Done manually directly on the Redis database:

- Completed/failed jobs were accumulating indefinitely (252K+ jobs, ~330MB) with no TTL, causing Redis OOM errors
- Existing stale jobs have been manually cleaned (372MB → 31MB)

## Test plan
- [ ] Verified server starts without OOM after cleanup