### PR TITLE
fix: close proposalActivityQueue on shutdown

### DIFF
--- a/src/queues/index.ts
+++ b/src/queues/index.ts
@@ -50,7 +50,7 @@ export function start() {
 }
 
 export function shutdown() {
-  return [mailerQueue.close(), scheduleQueue.close()];
+  return [mailerQueue.close(), scheduleQueue.close(), proposalActivityQueue.close()];
 }
 
 export function queueScheduler(options: Queue.JobOptions = {}) {


### PR DESCRIPTION
## Summary
- `shutdown()` was only closing `mailerQueue` and `scheduleQueue`, missing `proposalActivityQueue`
- This could leave dangling Redis connections on graceful shutdown

## Test plan
- [ ] Verify graceful shutdown closes all Redis connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)