### PR TITLE
chore: scope tsc compilation to src/ only

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,6 @@
     "sourceMap": true,
     "inlineSources": true,
     "sourceRoot": "/"
-  }
+  },
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary
- Adds `"include": ["src/**/*"]` to `tsconfig.json` so `tsc` no longer compiles `test/**/*.test.ts` into `dist/test/`.

## Why
Without `include`, tsc defaults to compiling every `.ts` file under `rootDir`, leaving 11 stale test artifacts in `dist/`.

## Verification
- `rm -rf dist && yarn build` — no `*.test.js` / `*.spec.js` files in `dist/` (was 11 before)
- `yarn typecheck` passes