### PR TITLE
chore: move CI to Node 22

### DIFF
--- a/.github/workflows/create-sentry-release.yml
+++ b/.github/workflows/create-sentry-release.yml
@@ -9,7 +9,7 @@ jobs:
   create-sentry-release:
     strategy:
       matrix:
-        target: ['18']
+        target: ['22']
     uses: snapshot-labs/actions/.github/workflows/create-sentry-release.yml@main
     secrets: inherit
     with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
   lint:
     strategy:
       matrix:
-        target: ['18']
+        target: ['22']
     uses: snapshot-labs/actions/.github/workflows/lint.yml@main
     secrets: inherit
     with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        target: ['18']
+        target: ['22']
     uses: snapshot-labs/actions/.github/workflows/test.yml@main
     secrets: inherit
     with:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     ]
   },
   "engines": {
-    "node": "^18.0.0"
+    "node": ">=22.6.0"
   },
   "prettier": "@snapshot-labs/prettier-config",
   "dependencies": {


### PR DESCRIPTION
## What

Move CI to Node 22 (Active LTS until Apr 2027):

- Workflow `target` set to `'22'` on lint, test, and create-sentry-release
- `package.json` `engines.node` set to `>=22.6.0` (matches sx-monorepo)

## Why

Node 18 is EOL. Newer `@snapshot-labs/eslint-config` requires `eslint-visitor-keys@5` whose engine needs `^20.19.0 || ^22.13.0 || >=24` — bumping CI to Node 22 unblocks the dependabot bump. Matches `blockfinder#505` (already merged) and `sx-monorepo` (already on Node 22).

## Test

CI `lint (22)` + `test (22)` should both go green on Node 22.